### PR TITLE
feat(bet): allow admins to edit bets on closed fixtures

### DIFF
--- a/app/ui/bolao/bet/__tests__/tableMatchDayBets.test.tsx
+++ b/app/ui/bolao/bet/__tests__/tableMatchDayBets.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/react"
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import TableMatchDayBets from "../tableMatchDayBets"
 import type { FixtureData, Bet } from "@/app/lib/definitions"
+
+vi.mock("@clerk/nextjs/server", () => ({
+  currentUser: vi.fn(),
+  clerkClient: vi.fn(),
+}))
 
 // Mock child components
 vi.mock("../buttonsBet", () => ({
@@ -58,6 +63,12 @@ async function renderTableMatchDayBets(props: {
 }
 
 describe("TableMatchDayBets", () => {
+  beforeEach(async () => {
+    const { currentUser, clerkClient } = await import("@clerk/nextjs/server")
+    vi.mocked(currentUser).mockResolvedValue(null)
+    vi.mocked(clerkClient).mockReset()
+  })
+
   const mockFixture: FixtureData = {
     fixture: {
       id: 12345,
@@ -271,6 +282,43 @@ describe("TableMatchDayBets", () => {
 
       expect(homeButtons).toHaveAttribute("data-disabled", "false")
       expect(awayButtons).toHaveAttribute("data-disabled", "false")
+    })
+  })
+
+  describe("Admin role — ButtonsBet disabled override", () => {
+    beforeEach(async () => {
+      const { currentUser, clerkClient } = await import("@clerk/nextjs/server")
+
+      vi.mocked(currentUser).mockResolvedValue({ id: "admin-user-1" } as never)
+
+      vi.mocked(clerkClient).mockResolvedValue({
+        users: {
+          getUser: vi.fn().mockResolvedValue({
+            privateMetadata: { role: "admin" },
+          }),
+        },
+      } as never)
+    })
+
+    it("should keep buttons enabled for finished fixtures when user is admin", async () => {
+      const finishedFixture = {
+        ...mockFixture,
+        fixture: {
+          ...mockFixture.fixture,
+          status: { long: "Match Finished", short: "FT", elapsed: 90 },
+        },
+      }
+
+      await renderTableMatchDayBets({ ...defaultProps, fixtures: [finishedFixture] })
+
+      expect(screen.getByTestId("buttons-bet-home-12345")).toHaveAttribute(
+        "data-disabled",
+        "false"
+      )
+      expect(screen.getByTestId("buttons-bet-away-12345")).toHaveAttribute(
+        "data-disabled",
+        "false"
+      )
     })
   })
 

--- a/app/ui/bolao/bet/tableMatchDayBets.tsx
+++ b/app/ui/bolao/bet/tableMatchDayBets.tsx
@@ -6,6 +6,7 @@ import TeamCodeLogo from "@/app/ui/bolao/teamCodeLogo"
 import TeamScore from "@/app/ui/bolao/teamScore"
 import FixtureDate from "@/app/ui/bolao/fixtureDate"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { clerkClient, currentUser } from "@clerk/nextjs/server"
 import clsx from "clsx"
 
 type TableProps = {
@@ -17,6 +18,14 @@ type TableProps = {
 async function TableMatchDayBets({ fixtures, userBolaoId, bets }: TableProps) {
   const t = await getTranslations("betPage")
   const locale = await getLocale()
+  let isAdmin = false
+  const user = await currentUser()
+  if (user) {
+    const client = await clerkClient()
+    const userData = await client.users.getUser(user.id)
+    const role = userData.privateMetadata?.role || "guest"
+    isAdmin = role === "admin"
+  }
 
   if (fixtures) {
     return (
@@ -34,7 +43,8 @@ async function TableMatchDayBets({ fixtures, userBolaoId, bets }: TableProps) {
           {fixtures.map((fixtureData: FixtureData, i: number) => {
             const statusShort = fixtureData.fixture.status.short
 
-            const disabled = !STATUSES_OPEN_TO_PLAY.includes(statusShort)
+            const fixtureClosed = !STATUSES_OPEN_TO_PLAY.includes(statusShort)
+            const disabled = !isAdmin && fixtureClosed
 
             const fixtureId = fixtureData.fixture.id.toString()
             const homeBet: Bet | null = findBetObj({


### PR DESCRIPTION
Enables **ButtonsBet** controls for users whose Clerk `privateMetadata.role` is `admin`, even when fixtures are outside `STATUSES_OPEN_TO_PLAY`. Non-admin behavior is unchanged.