### PR TITLE
i18n(pt-BR): shorter bolão tabs + stable e2e locale

### DIFF
--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -102,10 +102,10 @@
     "confirm": "Confirmar"
   },
   "bolaoLinks": {
-    "bet": "APOSTAR",
-    "standings": "CLASSIFICAÇÃO",
-    "results": "RESULTADOS",
-    "lead": "LIDERANÇA"
+    "bet": "APOSTA",
+    "standings": "TABELA",
+    "results": "PLACAR",
+    "lead": "RANKING"
   },
   "betPage": {
     "errorMissingUser": "Erro ao carregar a página de apostas. Usuário não encontrado.",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,14 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: "http://localhost:3000",
+    /**
+     * next-intl picks `pt-br` when Accept-Language starts with `pt` (see i18n/request.ts).
+     * E2E assertions use English copy, so pin locale + header for deterministic runs on any host/CI.
+     */
+    locale: "en-US",
+    extraHTTPHeaders: {
+      "Accept-Language": "en-US,en;q=0.9",
+    },
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
   },


### PR DESCRIPTION
## Summary
- **pt-BR:** Shorten `bolaoLinks` tab labels (`APOSTA`, `TABELA`, `PLACAR`, `RANKING`) so the bolão nav fits better on small screens.
- **e2e:** Pin `locale: en-US` and `Accept-Language` in Playwright so `next-intl` always serves English during tests (see `i18n/request.ts`).

Made with [Cursor](https://cursor.com)