### PR TITLE
Exclude relegation round names from bolão round list

### DIFF
--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -215,6 +215,18 @@ describe("utils", () => {
       ])
     })
 
+    it("should remove relegation rounds", () => {
+      const rounds = [
+        "Group Stage",
+        "Relegation rounds",
+        "Relegation round - quarter-finals",
+        "Final",
+      ]
+      const result = cleanRounds(rounds)
+
+      expect(result).toEqual(["Group Stage", "Final"])
+    })
+
     it("should return empty array when all rounds are removed", () => {
       const rounds = [
         "Preliminary Round",

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -120,6 +120,8 @@ const ROUNDS_TO_REMOVE: RegExp[] = [
   /^Play-offs$/,
   /^\d+(?:st|nd|rd|th) Qualifying Round$/,
   /^Qualification Round \d+$/,
+  // API uses singular + suffixes, e.g. "Relegation round - quarter-finals"
+  /^Relegation round/i,
 ]
 
 export const cleanRounds = (rounds: string[]): string[] => {


### PR DESCRIPTION
## Summary
- Broaden `cleanRounds` so API labels like `Relegation round - quarter-finals` (Ligue 1) are filtered, not only an exact `Relegation rounds` match.
- Use a case-insensitive prefix pattern `/^`Relegation round`/i`.
- Extend unit tests for relegation variants.

## Testing
- `yarn vitest run app/lib/__tests__/utils.test.ts`
- Pre-push hook ran full Vitest + Playwright (passed).

Made with [Cursor](https://cursor.com)