### PR TITLE
Fix default round when API current is an excluded label

### DIFF
--- a/app/lib/__tests__/controllerBet.test.ts
+++ b/app/lib/__tests__/controllerBet.test.ts
@@ -16,11 +16,15 @@ vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(),
 }))
 
-// Mock utility functions
-vi.mock("@/app/lib/utils", () => ({
-  sortFixtures: vi.fn((fixtures) => fixtures),
-  cleanRounds: vi.fn((rounds) => rounds),
-}))
+// Mock utility functions — keep pickCurrentRoundFromApiCurrent real so it exercises the mock cleanRounds
+vi.mock("@/app/lib/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/lib/utils")>()
+  return {
+    ...actual,
+    sortFixtures: vi.fn((fixtures) => fixtures),
+    cleanRounds: vi.fn((rounds) => rounds),
+  }
+})
 
 describe("controllerBet", () => {
   const mockBolao: Bolao = {

--- a/app/lib/__tests__/controllerResults.test.ts
+++ b/app/lib/__tests__/controllerResults.test.ts
@@ -16,11 +16,15 @@ vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(),
 }))
 
-// Mock utility functions
-vi.mock("@/app/lib/utils", () => ({
-  sortFixtures: vi.fn((fixtures) => fixtures),
-  cleanRounds: vi.fn((rounds) => rounds),
-}))
+// Mock utility functions — keep pickCurrentRoundFromApiCurrent real so it exercises the mock cleanRounds
+vi.mock("@/app/lib/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/lib/utils")>()
+  return {
+    ...actual,
+    sortFixtures: vi.fn((fixtures) => fixtures),
+    cleanRounds: vi.fn((rounds) => rounds),
+  }
+})
 
 describe("controllerResults", () => {
   const mockBolao: Bolao = {

--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -295,6 +295,10 @@ describe("utils", () => {
         "Matchday 36"
       )
     })
+
+    it("returns empty string when there are no cleaned season rounds", () => {
+      expect(pickCurrentRoundFromApiCurrent([], [], "first")).toBe("")
+    })
   })
 
   describe("findBetObj", () => {

--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatDateFixtures,
   formatDateNews,
   cleanRounds,
+  pickCurrentRoundFromApiCurrent,
   findBetObj,
   isNil,
   getEmailUsername,
@@ -253,6 +254,46 @@ describe("utils", () => {
       const result = cleanRounds([])
 
       expect(result).toEqual([])
+    })
+  })
+
+  describe("pickCurrentRoundFromApiCurrent", () => {
+    const season = ["Matchday 34", "Matchday 35", "Matchday 36"]
+
+    it("uses first allowed API current label (strategy first)", () => {
+      expect(
+        pickCurrentRoundFromApiCurrent(
+          ["Relegation round - quarter-finals", "Matchday 35"],
+          season,
+          "first"
+        )
+      ).toBe("Matchday 35")
+    })
+
+    it("uses last allowed API current label (strategy last)", () => {
+      expect(
+        pickCurrentRoundFromApiCurrent(
+          ["Matchday 34", "Relegation round - quarter-finals"],
+          season,
+          "last"
+        )
+      ).toBe("Matchday 34")
+    })
+
+    it("falls back to last cleaned season round when API current is only excluded labels", () => {
+      expect(
+        pickCurrentRoundFromApiCurrent(
+          ["Relegation round - semi-finals"],
+          season,
+          "first"
+        )
+      ).toBe("Matchday 36")
+    })
+
+    it("falls back when API returns no current labels", () => {
+      expect(pickCurrentRoundFromApiCurrent([], season, "first")).toBe(
+        "Matchday 36"
+      )
     })
   })
 

--- a/app/lib/controllerBet.ts
+++ b/app/lib/controllerBet.ts
@@ -6,7 +6,11 @@ import {
   fetchFixtures,
   fetchUserBets,
 } from "@/app/lib/data"
-import { sortFixtures, cleanRounds } from "@/app/lib/utils"
+import {
+  sortFixtures,
+  cleanRounds,
+  pickCurrentRoundFromApiCurrent,
+} from "@/app/lib/utils"
 import { Bet, PlayersData, UserBolao } from "@/app/lib/definitions"
 import { clerkClient } from "@clerk/nextjs/server"
 
@@ -71,9 +75,11 @@ export async function getData({
     year,
     current: true,
   }) // HAS TO GO TO STORE
-  const currentRound =
-    currentRoundObj[currentRoundObj.length - 1] ||
-    allRounds[allRounds.length - 1]
+  const currentRound = pickCurrentRoundFromApiCurrent(
+    currentRoundObj,
+    allRounds,
+    "last"
+  )
 
   let isFirstRound: boolean = false
   let isLastRound: boolean = false

--- a/app/lib/controllerResults.ts
+++ b/app/lib/controllerResults.ts
@@ -5,7 +5,11 @@ import {
   fetchFixtures,
   fetchUsersBets,
 } from "@/app/lib/data"
-import { sortFixtures, cleanRounds } from "@/app/lib/utils"
+import {
+  sortFixtures,
+  cleanRounds,
+  pickCurrentRoundFromApiCurrent,
+} from "@/app/lib/utils"
 import { Bet, UserBolao, PlayersData } from "@/app/lib/definitions"
 import { clerkClient } from "@clerk/nextjs/server"
 
@@ -60,7 +64,11 @@ export async function getData({
     current: true,
   })
 
-  const currentRound = currentRoundObj[0] || allRounds[allRounds.length - 1]
+  const currentRound = pickCurrentRoundFromApiCurrent(
+    currentRoundObj,
+    allRounds,
+    "first"
+  )
 
   let isFirstRound: boolean = false
   let isLastRound: boolean = false

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -130,6 +130,25 @@ export const cleanRounds = (rounds: string[]): string[] => {
   )
 }
 
+/**
+ * `fixtures/rounds?current=true` can return labels we strip from the season list (e.g. relegation).
+ * Choose the first or last label still allowed after {@link cleanRounds}, else the last cleaned round.
+ */
+export function pickCurrentRoundFromApiCurrent(
+  apiCurrentLabels: string[],
+  cleanedSeasonRounds: string[],
+  strategy: "first" | "last"
+): string | undefined {
+  const allowed = cleanRounds(apiCurrentLabels)
+  const fromApi =
+    strategy === "first"
+      ? allowed[0]
+      : allowed.length > 0
+        ? allowed[allowed.length - 1]
+        : undefined
+  return fromApi ?? cleanedSeasonRounds[cleanedSeasonRounds.length - 1]
+}
+
 export const INITIAL_BET_VALUE = "."
 
 export const findBetObj = ({

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -133,12 +133,13 @@ export const cleanRounds = (rounds: string[]): string[] => {
 /**
  * `fixtures/rounds?current=true` can return labels we strip from the season list (e.g. relegation).
  * Choose the first or last label still allowed after {@link cleanRounds}, else the last cleaned round.
+ * Returns `""` only when there are no cleaned season rounds (degenerate API data).
  */
 export function pickCurrentRoundFromApiCurrent(
   apiCurrentLabels: string[],
   cleanedSeasonRounds: string[],
   strategy: "first" | "last"
-): string | undefined {
+): string {
   const allowed = cleanRounds(apiCurrentLabels)
   const fromApi =
     strategy === "first"
@@ -146,7 +147,11 @@ export function pickCurrentRoundFromApiCurrent(
       : allowed.length > 0
         ? allowed[allowed.length - 1]
         : undefined
-  return fromApi ?? cleanedSeasonRounds[cleanedSeasonRounds.length - 1]
+  return (
+    fromApi ??
+    cleanedSeasonRounds[cleanedSeasonRounds.length - 1] ??
+    ""
+  )
 }
 
 export const INITIAL_BET_VALUE = "."


### PR DESCRIPTION
## Summary

Follow-up to the relegation round filter: `cleanRounds` only applied to the full season list, not to `fixtures/rounds?current=true`. When the API marked a relegation round as current, the UI still showed it on the default view.

- Add `pickCurrentRoundFromApiCurrent` in `app/lib/utils.ts` and use it from `controllerResults` / `controllerBet`.
- Controller tests: partial `importOriginal` mock so the new helper runs with the stubbed `cleanRounds`.
- Unit tests for the helper (relegation + fallback + degenerate empty season).
- **Build:** return type is `string` (`""` when API current and cleaned season are both empty) so strict TypeScript passes on `data.currentRound.toLowerCase()` in bet/results pages.

## Testing

Pre-push: full Vitest + Playwright (passed); `yarn build` passes after the return-type fix.