### PR TITLE
feat(ui): full-bleed bolão cards on small screens

### DIFF
--- a/app/ui/bolao/bet/tableMatchDayBets.tsx
+++ b/app/ui/bolao/bet/tableMatchDayBets.tsx
@@ -26,106 +26,113 @@ async function TableMatchDayBets({
 
   if (fixtures) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            {STATUSES_OPEN_TO_PLAY.includes(
-              fixtures[fixtures.length - 1].fixture.status.short
-            )
-              ? t("nextGames")
-              : t("previousGames")}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {fixtures.map((fixtureData: FixtureData, i: number) => {
-            const statusShort = fixtureData.fixture.status.short
+      <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
+        <Card
+          className={clsx(
+            "max-md:rounded-none max-md:border-x-0 max-md:shadow-none",
+            "md:rounded-xl md:border-x md:shadow-sm"
+          )}
+        >
+          <CardHeader className="p-4 md:p-6">
+            <CardTitle>
+              {STATUSES_OPEN_TO_PLAY.includes(
+                fixtures[fixtures.length - 1].fixture.status.short
+              )
+                ? t("nextGames")
+                : t("previousGames")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {fixtures.map((fixtureData: FixtureData, i: number) => {
+              const statusShort = fixtureData.fixture.status.short
 
-            const fixtureClosed = !STATUSES_OPEN_TO_PLAY.includes(statusShort)
-            const disabled = !isAdmin && fixtureClosed
+              const fixtureClosed = !STATUSES_OPEN_TO_PLAY.includes(statusShort)
+              const disabled = !isAdmin && fixtureClosed
 
-            const fixtureId = fixtureData.fixture.id.toString()
-            const homeBet: Bet | null = findBetObj({
-              bets,
-              fixtureId,
-              type: "home",
-            })
+              const fixtureId = fixtureData.fixture.id.toString()
+              const homeBet: Bet | null = findBetObj({
+                bets,
+                fixtureId,
+                type: "home",
+              })
 
-            const awayBet: Bet | null = findBetObj({
-              bets,
-              fixtureId,
-              type: "away",
-            })
+              const awayBet: Bet | null = findBetObj({
+                bets,
+                fixtureId,
+                type: "away",
+              })
 
-            return (
-              <div
-                key={fixtureId}
-                className={clsx("py-4", {
-                  "bg-slate-50": i % 2 !== 0,
-                })}
-              >
-                <div className="flex justify-center content-center">
-                  <ButtonsBet
-                    key={`${userBolaoId}_${fixtureId}_home_${homeBet?.id || "new"}`}
-                    fixtureId={fixtureId}
-                    type="home"
-                    userBolaoId={userBolaoId}
-                    betValue={homeBet?.value}
-                    betId={homeBet?.id}
-                    disabled={disabled}
-                  />
-
-                  <TeamCodeLogo
-                    logoSrc={fixtureData.teams.home.logo}
-                    name={fixtureData.teams.home.name}
-                  />
-
-                  <div className="flex flex-col items-center">
-                    <FixtureDate
-                      date={fixtureData.fixture.date.toString()}
-                      status={fixtureData.fixture.status}
-                      locale={locale}
+              return (
+                <div
+                  key={fixtureId}
+                  className={clsx("py-4", {
+                    "bg-slate-50": i % 2 !== 0,
+                  })}
+                >
+                  <div className="flex justify-center content-center">
+                    <ButtonsBet
+                      key={`${userBolaoId}_${fixtureId}_home_${homeBet?.id || "new"}`}
+                      fixtureId={fixtureId}
+                      type="home"
+                      userBolaoId={userBolaoId}
+                      betValue={homeBet?.value}
+                      betId={homeBet?.id}
+                      disabled={disabled}
                     />
-                    <div className="flex flex-row">
-                      <TeamScore
-                        score={fixtureData.score}
-                        goals={fixtureData.goals}
-                        type="home"
-                        status={statusShort}
-                      />
 
-                      <span className="mx-3 text-xs content-center">
-                        &times;
-                      </span>
+                    <TeamCodeLogo
+                      logoSrc={fixtureData.teams.home.logo}
+                      name={fixtureData.teams.home.name}
+                    />
 
-                      <TeamScore
-                        score={fixtureData.score}
-                        goals={fixtureData.goals}
-                        type="away"
-                        status={statusShort}
+                    <div className="flex flex-col items-center">
+                      <FixtureDate
+                        date={fixtureData.fixture.date.toString()}
+                        status={fixtureData.fixture.status}
+                        locale={locale}
                       />
+                      <div className="flex flex-row">
+                        <TeamScore
+                          score={fixtureData.score}
+                          goals={fixtureData.goals}
+                          type="home"
+                          status={statusShort}
+                        />
+
+                        <span className="mx-3 text-xs content-center">
+                          &times;
+                        </span>
+
+                        <TeamScore
+                          score={fixtureData.score}
+                          goals={fixtureData.goals}
+                          type="away"
+                          status={statusShort}
+                        />
+                      </div>
                     </div>
+
+                    <TeamCodeLogo
+                      logoSrc={fixtureData.teams.away.logo}
+                      name={fixtureData.teams.away.name}
+                    />
+
+                    <ButtonsBet
+                      key={`${userBolaoId}_${fixtureId}_away_${awayBet?.id || "new"}`}
+                      fixtureId={fixtureId}
+                      type="away"
+                      userBolaoId={userBolaoId}
+                      betValue={awayBet?.value}
+                      betId={awayBet?.id}
+                      disabled={disabled}
+                    />
                   </div>
-
-                  <TeamCodeLogo
-                    logoSrc={fixtureData.teams.away.logo}
-                    name={fixtureData.teams.away.name}
-                  />
-
-                  <ButtonsBet
-                    key={`${userBolaoId}_${fixtureId}_away_${awayBet?.id || "new"}`}
-                    fixtureId={fixtureId}
-                    type="away"
-                    userBolaoId={userBolaoId}
-                    betValue={awayBet?.value}
-                    betId={awayBet?.id}
-                    disabled={disabled}
-                  />
                 </div>
-              </div>
-            )
-          })}
-        </CardContent>
-      </Card>
+              )
+            })}
+          </CardContent>
+        </Card>
+      </div>
     )
   }
 

--- a/app/ui/bolao/lead/tableLead.tsx
+++ b/app/ui/bolao/lead/tableLead.tsx
@@ -13,11 +13,12 @@ async function TableLead({ data }: TableProps) {
   const t = await getTranslations("leadPage")
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t("title")}</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
+      <Card className="max-md:rounded-none max-md:border-x-0 max-md:shadow-none md:rounded-xl md:border-x md:shadow-sm">
+        <CardHeader className="p-4 md:p-6">
+          <CardTitle>{t("title")}</CardTitle>
+        </CardHeader>
+        <CardContent>
         <table className="w-full text-xs">
           <thead className="uppercase">
             <tr>
@@ -73,8 +74,9 @@ async function TableLead({ data }: TableProps) {
             })}
           </tbody>
         </table>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </div>
   )
 }
 

--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -84,17 +84,18 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
 
   if (fixtures) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            {STATUSES_OPEN_TO_PLAY.includes(
-              fixtures[fixtures.length - 1].fixture.status.short
-            )
-              ? t("nextGames")
-              : t("previousGames")}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+      <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
+        <Card className="max-md:rounded-none max-md:border-x-0 max-md:shadow-none md:rounded-xl md:border-x md:shadow-sm">
+          <CardHeader className="p-4 md:p-6">
+            <CardTitle>
+              {STATUSES_OPEN_TO_PLAY.includes(
+                fixtures[fixtures.length - 1].fixture.status.short
+              )
+                ? t("nextGames")
+                : t("previousGames")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
           <StickyTable borderWidth={0}>
             <Row>
               <Cell style={cellStyles}>&nbsp;</Cell>
@@ -253,7 +254,8 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
             </Row>
           </StickyTable>
         </CardContent>
-      </Card>
+        </Card>
+      </div>
     )
   }
 

--- a/app/ui/bolao/standings/tableStandings.tsx
+++ b/app/ui/bolao/standings/tableStandings.tsx
@@ -92,25 +92,28 @@ async function TableStandings({ standingsLeague }: TableProps) {
 
   if (!standings || standings.length === 0) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle>{t("title")}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-center text-slate-500 py-8">
-            {t("noStandings")}
-          </div>
-        </CardContent>
-      </Card>
+      <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
+        <Card className="max-md:rounded-none max-md:border-x-0 max-md:shadow-none md:rounded-xl md:border-x md:shadow-sm">
+          <CardHeader className="p-4 md:p-6">
+            <CardTitle>{t("title")}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-center text-slate-500 py-8">
+              {t("noStandings")}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     )
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t("title")}</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
+      <Card className="max-md:rounded-none max-md:border-x-0 max-md:shadow-none md:rounded-xl md:border-x md:shadow-sm">
+        <CardHeader className="p-4 md:p-6">
+          <CardTitle>{t("title")}</CardTitle>
+        </CardHeader>
+        <CardContent>
         {standingsLeague.standings.map(
           (standingGroup: StandingsGroup, i: number) => (
             <table
@@ -217,8 +220,9 @@ async function TableStandings({ standingsLeague }: TableProps) {
             )
           })}
         </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Bolão **bet**, **results**, **lead**, and **standings** pages use the same root `container` + horizontal padding, which left the main table cards inset on narrow viewports and cramped dense rows (especially the bet row).

## Changes

- Wrap each page’s primary `Card` in a small-screen-only full-bleed wrapper using `max-md:mx-[calc((100dvw-100%)/-2)]` and `md:mx-0`, so width matches the viewport without changing global layout.
- On `max-md`, cards use flush sides (`rounded-none`, `border-x-0`, `shadow-none`); from `md` up, styling matches the previous shadcn defaults.
- `CardHeader` uses `p-4 md:p-6` for slightly more horizontal room on small screens.

## Files

- `app/ui/bolao/bet/tableMatchDayBets.tsx`
- `app/ui/bolao/results/tableMatchDayResults.tsx`
- `app/ui/bolao/lead/tableLead.tsx`
- `app/ui/bolao/standings/tableStandings.tsx` (empty + populated branches)

## Testing

- `vitest run` on the affected component test files (table match day bets/results, table lead, table standings) passes.

Made with [Cursor](https://cursor.com)