### PR TITLE
fix(ui): handle broken team logos gracefully

### DIFF
--- a/app/ui/bolao/__tests__/teamCodeLogo.test.tsx
+++ b/app/ui/bolao/__tests__/teamCodeLogo.test.tsx
@@ -1,11 +1,17 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, it, expect, vi } from "vitest"
 import TeamCodeLogo from "../teamCodeLogo"
 
 // Mock Next.js Image
 vi.mock("next/image", () => ({
-  default: ({ src, alt, className }: any) => (
-    <img src={src} alt={alt} className={className} data-testid="team-logo" />
+  default: ({ src, alt, className, onError }: any) => (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      onError={onError}
+      data-testid="team-logo"
+    />
   ),
 }))
 
@@ -135,6 +141,24 @@ describe("TeamCodeLogo", () => {
 
       const logo = screen.getByTestId("team-logo")
       expect(logo).toBeInTheDocument()
+    })
+
+    it("should show a fallback when the logo fails to load", () => {
+      render(<TeamCodeLogo name="Saint Etienne" logoSrc="/broken-logo.png" />)
+
+      fireEvent.error(screen.getByTestId("team-logo"))
+
+      expect(screen.queryByTestId("team-logo")).not.toBeInTheDocument()
+      expect(screen.getByText("S")).toBeInTheDocument()
+      expect(screen.getByText("SAI")).toBeInTheDocument()
+    })
+
+    it("should show a fallback when the logo source is empty", () => {
+      render(<TeamCodeLogo name="Saint Etienne" logoSrc="" />)
+
+      expect(screen.queryByTestId("team-logo")).not.toBeInTheDocument()
+      expect(screen.getByText("S")).toBeInTheDocument()
+      expect(screen.getByText("SAI")).toBeInTheDocument()
     })
   })
 

--- a/app/ui/bolao/__tests__/teamCodeLogo.test.tsx
+++ b/app/ui/bolao/__tests__/teamCodeLogo.test.tsx
@@ -4,12 +4,13 @@ import TeamCodeLogo from "../teamCodeLogo"
 
 // Mock Next.js Image
 vi.mock("next/image", () => ({
-  default: ({ src, alt, className, onError }: any) => (
+  default: ({ src, alt, className, onError, onLoad }: any) => (
     <img
       src={src}
       alt={alt}
       className={className}
       onError={onError}
+      onLoad={onLoad}
       data-testid="team-logo"
     />
   ),
@@ -143,6 +144,14 @@ describe("TeamCodeLogo", () => {
       expect(logo).toBeInTheDocument()
     })
 
+    it("should show the fallback immediately while the logo is still loading", () => {
+      render(<TeamCodeLogo name="Saint Etienne" logoSrc="/slow-logo.png" />)
+
+      expect(screen.getByTestId("team-logo")).toBeInTheDocument()
+      expect(screen.getByText("S")).toBeInTheDocument()
+      expect(screen.getByText("SAI")).toBeInTheDocument()
+    })
+
     it("should show a fallback when the logo fails to load", () => {
       render(<TeamCodeLogo name="Saint Etienne" logoSrc="/broken-logo.png" />)
 
@@ -239,9 +248,10 @@ describe("TeamCodeLogo", () => {
     })
 
     it("should handle single character team names", () => {
-      render(<TeamCodeLogo name="A" logoSrc="/logo.png" />)
+      const { container } = render(<TeamCodeLogo name="A" logoSrc="/logo.png" />)
 
-      expect(screen.getByText("A")).toBeInTheDocument()
+      const teamCode = container.querySelector(".text-sm.text-center")
+      expect(teamCode).toHaveTextContent("A")
     })
   })
 

--- a/app/ui/bolao/bolaoPageTitle.tsx
+++ b/app/ui/bolao/bolaoPageTitle.tsx
@@ -28,23 +28,14 @@ function BolaoPageTitle({ leagueName, leagueLogo, bolao }: Props) {
     <PageTitle center={true}>
       {logoSrc && (
         <div className="flex justify-center mb-6">
-          {useWc2026Silhouette ? (
-            <img
-              src={logoSrc}
-              alt={`${leagueName ?? "2026 FIFA World Cup"}'s logo`}
-              width={227}
-              height={351}
-              className="h-[4.5rem] w-auto"
-              data-testid="league-logo"
-            />
-          ) : (
-            <Image
-              alt={`${leagueName}'s logo`}
-              src={logoSrc}
-              width={60}
-              height={60}
-            />
-          )}
+          <Image
+            alt={`${leagueName ?? "2026 FIFA World Cup"}'s logo`}
+            src={logoSrc}
+            width={useWc2026Silhouette ? 227 : 60}
+            height={useWc2026Silhouette ? 351 : 60}
+            className={useWc2026Silhouette ? "h-[4.5rem] w-auto" : undefined}
+            data-testid="league-logo"
+          />
         </div>
       )}
 

--- a/app/ui/bolao/teamCodeLogo.tsx
+++ b/app/ui/bolao/teamCodeLogo.tsx
@@ -1,6 +1,6 @@
 "use client" // keep this to trigger the popovers on mobile
 
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import Image from "next/image"
 import {
   Tooltip,
@@ -24,29 +24,34 @@ const formatTeamCode = (name: string) =>
   name.toUpperCase().replace(" ", "").slice(0, 3)
 
 function TeamCodeLogo({ name, logoSrc }: Props) {
-  const [imageError, setImageError] = useState(false)
+  const [failedLogoSrc, setFailedLogoSrc] = useState<string | null>(null)
+  const [loadedLogoSrc, setLoadedLogoSrc] = useState<string | null>(null)
   const teamCode = useMemo(() => formatTeamCode(name), [name])
   const fallbackLabel = teamCode.charAt(0) || "?"
+  const shouldRenderImage = Boolean(logoSrc) && failedLogoSrc !== logoSrc
+  const isImageLoaded = loadedLogoSrc === logoSrc
 
-  useEffect(() => {
-    setImageError(false)
-  }, [logoSrc])
-
-  const triggerElement =
-    imageError || !logoSrc ? (
-      <span className="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-slate-200 text-[10px] font-semibold text-slate-500">
+  const triggerElement = (
+    <span className="relative inline-flex h-5 w-5 items-center justify-center">
+      <span
+        aria-hidden="true"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-slate-200 text-[10px] font-semibold text-slate-500"
+      >
         {fallbackLabel}
       </span>
-    ) : (
-      <Image
-        width={100} // Placeholder width
-        height={100} // Placeholder height
-        className="max-h-5 max-w-5 object-contain"
-        src={logoSrc}
-        alt={`${name}'s logo`}
-        onError={() => setImageError(true)}
-      />
-    )
+      {shouldRenderImage && (
+        <Image
+          width={100} // Placeholder width
+          height={100} // Placeholder height
+          className={`absolute inset-0 max-h-5 max-w-5 object-contain ${isImageLoaded ? "opacity-100" : "opacity-0"}`}
+          src={logoSrc}
+          alt={`${name}'s logo`}
+          onLoad={() => setLoadedLogoSrc(logoSrc)}
+          onError={() => setFailedLogoSrc(logoSrc)}
+        />
+      )}
+    </span>
+  )
 
   if (isBrowser) {
     return (

--- a/app/ui/bolao/teamCodeLogo.tsx
+++ b/app/ui/bolao/teamCodeLogo.tsx
@@ -1,5 +1,6 @@
 "use client" // keep this to trigger the popovers on mobile
 
+import { useEffect, useMemo, useState } from "react"
 import Image from "next/image"
 import {
   Tooltip,
@@ -23,15 +24,29 @@ const formatTeamCode = (name: string) =>
   name.toUpperCase().replace(" ", "").slice(0, 3)
 
 function TeamCodeLogo({ name, logoSrc }: Props) {
-  const triggerElement = (
-    <Image
-      width={100} // Placeholder width
-      height={100} // Placeholder height
-      className="max-h-5 max-w-5 object-contain"
-      src={logoSrc}
-      alt={`${name}'s logo`}
-    />
-  )
+  const [imageError, setImageError] = useState(false)
+  const teamCode = useMemo(() => formatTeamCode(name), [name])
+  const fallbackLabel = teamCode.charAt(0) || "?"
+
+  useEffect(() => {
+    setImageError(false)
+  }, [logoSrc])
+
+  const triggerElement =
+    imageError || !logoSrc ? (
+      <span className="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-slate-200 text-[10px] font-semibold text-slate-500">
+        {fallbackLabel}
+      </span>
+    ) : (
+      <Image
+        width={100} // Placeholder width
+        height={100} // Placeholder height
+        className="max-h-5 max-w-5 object-contain"
+        src={logoSrc}
+        alt={`${name}'s logo`}
+        onError={() => setImageError(true)}
+      />
+    )
 
   if (isBrowser) {
     return (
@@ -44,7 +59,7 @@ function TeamCodeLogo({ name, logoSrc }: Props) {
             </Tooltip>
           </TooltipProvider>
         </span>
-        <span className="text-sm text-center">{formatTeamCode(name)}</span>
+        <span className="text-sm text-center">{teamCode}</span>
       </span>
     )
   }
@@ -54,7 +69,7 @@ function TeamCodeLogo({ name, logoSrc }: Props) {
       <PopoverTrigger asChild>
         <button className="flex items-center justify-center flex-col mx-3">
           {triggerElement}
-          <span className="text-sm text-center">{formatTeamCode(name)}</span>
+          <span className="text-sm text-center">{teamCode}</span>
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-auto">


### PR DESCRIPTION
## Summary
- add a fallback badge in `TeamCodeLogo` for missing or broken remote team crests
- render that fallback immediately and only reveal the remote logo after it loads so slow failures do not leave an empty gap
- replace the remaining raw image in `BolaoPageTitle` with `next/image` to preserve the 2026 World Cup sizing without the lint warning
- cover broken-image, empty-src, and slow-loading logo behavior in the shared team logo tests

## Test plan
- [x] `yarn vitest --run app/ui/bolao/__tests__/teamCodeLogo.test.tsx`
- [x] `yarn vitest --run app/ui/bolao/__tests__/bolaoPageTitle.test.tsx`
- [x] `yarn lint`