### PR TITLE
Improve Vercel caching and split the authenticated dashboard

### DIFF
--- a/app/__tests__/page.test.tsx
+++ b/app/__tests__/page.test.tsx
@@ -1,43 +1,36 @@
-import { render, screen, cleanup } from "@testing-library/react"
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
 import Home from "../page"
 
-// Mock Clerk currentUser
-vi.mock("@clerk/nextjs/server", () => ({
-  currentUser: vi.fn(),
-}))
-
-// Mock PageTitle component
 vi.mock("@/app/components/pageTitle", () => ({
   default: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="page-title">{children}</div>
   ),
 }))
 
-// Mock InviteRedirector component
 vi.mock("@/app/components/InviteRedirector", () => ({
   default: () => <div data-testid="invite-redirector" />,
 }))
 
-// Mock BoloesList component
-vi.mock("@/app/ui/home/boloesList", () => ({
-  default: () => <div data-testid="boloes-list">BoloesList Component</div>,
+vi.mock("@/app/components/homeHeroActions", () => ({
+  default: () => <div data-testid="home-hero-actions" />,
 }))
 
-// Mock BoloesListSkeleton
-vi.mock("@/app/ui/skeletons", () => ({
-  BoloesListSkeleton: () => <div data-testid="skeleton">Loading...</div>,
-}))
-
-// Mock Next.js Link
 vi.mock("next/link", () => ({
   default: ({
     children,
     href,
+    className,
   }: {
     children: React.ReactNode
     href: string
-  }) => <a href={href}>{children}</a>,
+    className?: string
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
 }))
 
 describe("Home Page", () => {
@@ -45,476 +38,51 @@ describe("Home Page", () => {
     vi.clearAllMocks()
   })
 
-  describe("Authenticated User State", () => {
-    it("should render page with InviteRedirector when user is authenticated", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
+  it("renders the landing page shell and invite redirector", async () => {
+    const { container } = render(await Home())
 
-      render(await Home())
-
-      expect(screen.getByTestId("invite-redirector")).toBeInTheDocument()
-    })
-
-    it("should display greeting with username when username exists", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "johndoe",
-        emailAddresses: [{ emailAddress: "john@example.com" }],
-      } as any)
-
-      render(await Home())
-
-      expect(screen.getByText("Hey")).toBeInTheDocument()
-      expect(screen.getByText("johndoe.")).toBeInTheDocument()
-    })
-
-    it("should display greeting with email prefix when username is missing", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: null,
-        emailAddresses: [{ emailAddress: "jane@example.com" }],
-      } as any)
-
-      render(await Home())
-
-      expect(screen.getByText("Hey")).toBeInTheDocument()
-      expect(screen.getByText("jane")).toBeInTheDocument()
-    })
-
-    it("should render BoloesList component when user is authenticated", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      render(await Home())
-
-      expect(screen.getByTestId("boloes-list")).toBeInTheDocument()
-    })
-
-    it("should render main element with authenticated content", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      const { container } = render(await Home())
-
-      const mainElement = container.querySelector("main")
-      expect(mainElement).toBeInTheDocument()
-    })
-
-    it("should render PageTitle component for authenticated user", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      render(await Home())
-
-      expect(screen.getByTestId("page-title")).toBeInTheDocument()
-    })
-
-    it("should apply bold styling to username", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "bolduser",
-        emailAddresses: [{ emailAddress: "bold@example.com" }],
-      } as any)
-
-      const { container } = render(await Home())
-
-      const boldElement = container.querySelector(".font-bold")
-      expect(boldElement).toBeInTheDocument()
-      expect(boldElement?.textContent).toBe("bolduser.")
-    })
+    expect(screen.getByTestId("invite-redirector")).toBeInTheDocument()
+    expect(screen.getByTestId("page-title")).toBeInTheDocument()
+    expect(container.querySelector("main.max-w-4xl")).toBeInTheDocument()
   })
 
-  describe("Unauthenticated User State", () => {
-    it("should render page with InviteRedirector when user is not authenticated", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
+  it("renders hero content and home actions", async () => {
+    render(await Home())
 
-      render(await Home())
-
-      expect(screen.getByTestId("invite-redirector")).toBeInTheDocument()
-    })
-
-    it("should display hero title for unauthenticated user", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(
-        screen.getByText("Soccer betting pools with friends.")
-      ).toBeInTheDocument()
-    })
-
-    it("should display hero subtitle with value propositions", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(screen.getByText(/Compete on predictions/i)).toBeInTheDocument()
-      expect(
-        screen.getByText(/Track results in real-time/i)
-      ).toBeInTheDocument()
-      expect(screen.getByText(/Win bragging rights/i)).toBeInTheDocument()
-    })
-
-    it("should render GET STARTED button with correct link", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      const getStartedLinks = screen.getAllByRole("link", {
-        name: /GET STARTED/i,
-      })
-      expect(getStartedLinks.length).toBeGreaterThan(0)
-      expect(getStartedLinks[0]).toHaveAttribute("href", "/sign-up")
-    })
-
-    it("should render LOGIN button with correct link", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      const loginLink = screen.getByRole("link", { name: /^LOGIN$/i })
-      expect(loginLink).toBeInTheDocument()
-      expect(loginLink).toHaveAttribute("href", "/sign-in")
-    })
-
-    it("should render Learn more about Bolão.io link", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      const aboutLink = screen.getByRole("link", {
-        name: /Learn more about Bolão\.io/i,
-      })
-      expect(aboutLink).toBeInTheDocument()
-      expect(aboutLink).toHaveAttribute("href", "/about")
-    })
-
-    it("should display What is a bolão section", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(
-        screen.getByRole("heading", { name: /What is a bolão\?/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(/In Brazil, a bolão is a betting pool/i)
-      ).toBeInTheDocument()
-      expect(screen.getByText(/just friendly competition/i)).toBeInTheDocument()
-    })
-
-    it("should display How it works section with 3 steps", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(
-        screen.getByRole("heading", { name: /How it works/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("heading", { name: /Create or Join/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("heading", { name: /Make Predictions/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("heading", { name: /Track & Win/i })
-      ).toBeInTheDocument()
-    })
-
-    it("should display Why Bolão.io features section", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(
-        screen.getByRole("heading", { name: /Why Bolão\.io\?/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("heading", { name: /Multiple Leagues/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("heading", { name: /Works Everywhere/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("heading", { name: /Completely Free/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("heading", { name: /Real-Time Updates/i })
-      ).toBeInTheDocument()
-    })
-
-    it("should display Ready to start CTA section", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(
-        screen.getByRole("heading", { name: /Ready to start\?/i })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(/Create your first bolão in minutes/i)
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("link", { name: /GET STARTED FOR FREE/i })
-      ).toBeInTheDocument()
-    })
-
-    it("should not render BoloesList when user is not authenticated", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(screen.queryByTestId("boloes-list")).not.toBeInTheDocument()
-    })
-
-    it("should render PageTitle for unauthenticated user", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      expect(screen.getByTestId("page-title")).toBeInTheDocument()
-    })
-
-    it("should render main element with max-width wrapper", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      const { container } = render(await Home())
-
-      const mainElement = container.querySelector("main.max-w-4xl")
-      expect(mainElement).toBeInTheDocument()
-    })
+    expect(
+      screen.getByText("Soccer betting pools with friends.")
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Compete on predictions/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Track results in real-time/i)
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("home-hero-actions")).toBeInTheDocument()
   })
 
-  describe("Component Structure", () => {
-    it("should have consistent main wrapper for both states", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
+  it("renders the learn more link to the about page", async () => {
+    render(await Home())
 
-      // Test authenticated state
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      const { container: authenticatedContainer } = render(await Home())
-      expect(authenticatedContainer.querySelector("main")).toBeInTheDocument()
-
-      cleanup()
-
-      // Test unauthenticated state
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      const { container: unauthenticatedContainer } = render(await Home())
-      expect(unauthenticatedContainer.querySelector("main")).toBeInTheDocument()
+    const aboutLink = screen.getByRole("link", {
+      name: /Learn more about Bolão\.io/i,
     })
 
-    it("should always render InviteRedirector regardless of auth state", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-
-      // Test authenticated state
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      const authenticatedRender = render(await Home())
-      expect(
-        authenticatedRender.getByTestId("invite-redirector")
-      ).toBeInTheDocument()
-
-      cleanup()
-
-      // Test unauthenticated state
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      const unauthenticatedRender = render(await Home())
-      expect(
-        unauthenticatedRender.getByTestId("invite-redirector")
-      ).toBeInTheDocument()
-    })
-
-    it("should always render PageTitle regardless of auth state", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-
-      // Test authenticated state
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      const authenticatedRender = render(await Home())
-      expect(authenticatedRender.getByTestId("page-title")).toBeInTheDocument()
-
-      cleanup()
-
-      // Test unauthenticated state
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      const unauthenticatedRender = render(await Home())
-      expect(
-        unauthenticatedRender.getByTestId("page-title")
-      ).toBeInTheDocument()
-    })
+    expect(aboutLink).toHaveAttribute("href", "/about")
   })
 
-  describe("Accessibility", () => {
-    it("should use semantic main element for authenticated state", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
+  it("renders the marketing sections below the hero", async () => {
+    render(await Home())
 
-      const { container } = render(await Home())
-
-      const main = container.querySelector("main")
-      expect(main).toBeInTheDocument()
-    })
-
-    it("should use semantic main element for unauthenticated state", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      const { container } = render(await Home())
-
-      const main = container.querySelector("main")
-      expect(main).toBeInTheDocument()
-    })
-
-    it("should have accessible links with descriptive text", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      render(await Home())
-
-      const loginLink = screen.getByRole("link", { name: /^LOGIN$/i })
-      const aboutLink = screen.getByRole("link", {
-        name: /Learn more about Bolão\.io/i,
-      })
-
-      expect(loginLink.textContent).toBe("LOGIN")
-      expect(aboutLink.textContent).toBe("Learn more about Bolão.io")
-    })
-
-    it("should use br tag for greeting line break", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      const { container } = render(await Home())
-
-      const brElement = container.querySelector("br")
-      expect(brElement).toBeInTheDocument()
-    })
-
-    it("should have proper heading hierarchy in unauthenticated view", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue(null)
-
-      const { container } = render(await Home())
-
-      const h2Elements = container.querySelectorAll("h2")
-      const h3Elements = container.querySelectorAll("h3")
-
-      expect(h2Elements.length).toBeGreaterThan(0)
-      expect(h3Elements.length).toBeGreaterThan(0)
-    })
-  })
-
-  describe("Suspense Behavior", () => {
-    it("should wrap BoloesList in Suspense boundary", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      // Since we're testing a server component, Suspense is resolved
-      render(await Home())
-
-      expect(screen.getByTestId("boloes-list")).toBeInTheDocument()
-    })
-  })
-
-  describe("User Data Handling", () => {
-    it("should correctly extract email local part from standard email", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: null,
-        emailAddresses: [{ emailAddress: "simple@test.com" }],
-      } as any)
-
-      render(await Home())
-
-      expect(screen.getByText("simple")).toBeInTheDocument()
-    })
-
-    it("should prioritize username over email when both exist", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "preferred",
-        emailAddresses: [{ emailAddress: "alternative@test.com" }],
-      } as any)
-
-      render(await Home())
-
-      expect(screen.getByText("preferred.")).toBeInTheDocument()
-      expect(screen.queryByText("alternative")).not.toBeInTheDocument()
-    })
-
-    it("should add period after username", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: "testuser",
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      render(await Home())
-
-      const usernameElement = screen.getByText("testuser.")
-      expect(usernameElement).toBeInTheDocument()
-      expect(usernameElement.textContent).toMatch(/\.$/)
-    })
-
-    it("should not add period after email prefix", async () => {
-      const { currentUser } = await import("@clerk/nextjs/server")
-      vi.mocked(currentUser).mockResolvedValue({
-        username: null,
-        emailAddresses: [{ emailAddress: "test@example.com" }],
-      } as any)
-
-      render(await Home())
-
-      const emailElement = screen.getByText("test")
-      expect(emailElement).toBeInTheDocument()
-      expect(emailElement.textContent).not.toMatch(/\.$/)
-    })
+    expect(
+      screen.getByRole("heading", { name: /What is a bolão\?/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: /How it works/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: /Why Bolão\.io\?/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: /Ready to start\?/i })
+    ).toBeInTheDocument()
   })
 })

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link"
 import { getTranslations } from "next-intl/server"
 import PageTitle from "@/app/components/pageTitle"
 
+export const revalidate = 3600
+
 const pClasses = "mb-10"
 const h2Classes = "text-2xl mb-6 text-center"
 const linkClasses = "underline hover:no-underline"

--- a/app/api/cacheHeaders.ts
+++ b/app/api/cacheHeaders.ts
@@ -1,0 +1,11 @@
+export async function applyNoStoreHeaders(
+  responseOrPromise: Response | Promise<Response>
+) {
+  const response = await responseOrPromise
+
+  response.headers.set("Cache-Control", "private, no-store, max-age=0")
+  response.headers.set("CDN-Cache-Control", "no-store")
+  response.headers.set("Vercel-CDN-Cache-Control", "no-store")
+
+  return response
+}

--- a/app/api/exit-preview/route.ts
+++ b/app/api/exit-preview/route.ts
@@ -1,5 +1,6 @@
 import { exitPreview } from "@prismicio/next"
+import { applyNoStoreHeaders } from "../cacheHeaders"
 
-export function GET() {
-  return exitPreview()
+export async function GET() {
+  return await applyNoStoreHeaders(exitPreview())
 }

--- a/app/api/preview/route.ts
+++ b/app/api/preview/route.ts
@@ -2,9 +2,12 @@ import { NextRequest } from "next/server"
 import { redirectToPreviewURL } from "@prismicio/next"
 
 import { createClient } from "../../../prismicio"
+import { applyNoStoreHeaders } from "../cacheHeaders"
 
 export async function GET(request: NextRequest) {
   const client = createClient()
 
-  return await redirectToPreviewURL({ client, request })
+  const response = await redirectToPreviewURL({ client, request })
+
+  return applyNoStoreHeaders(response)
 }

--- a/app/api/revalidate/__tests__/route.test.ts
+++ b/app/api/revalidate/__tests__/route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}))
+
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>()
+
+  return {
+    ...actual,
+  }
+})
+
+import { revalidatePath, revalidateTag } from "next/cache"
+import { POST } from "../route"
+
+describe("api/revalidate route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it("returns 500 when the revalidation secret is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/revalidate", { method: "POST" })
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: "REVALIDATE_SECRET is not configured.",
+    })
+  })
+
+  it("returns 401 when the provided secret is invalid", async () => {
+    vi.stubEnv("REVALIDATE_SECRET", "top-secret")
+
+    const response = await POST(
+      new Request("http://localhost/api/revalidate", {
+        method: "POST",
+        body: JSON.stringify({ secret: "wrong-secret" }),
+      })
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: "Unauthorized.",
+    })
+  })
+
+  it("revalidates the default prismic tag with a valid header secret", async () => {
+    vi.stubEnv("REVALIDATE_SECRET", "top-secret")
+
+    const response = await POST(
+      new Request("http://localhost/api/revalidate", {
+        method: "POST",
+        headers: {
+          "x-revalidate-secret": "top-secret",
+        },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(revalidateTag).toHaveBeenCalledWith("prismic", { expire: 0 })
+    expect(revalidatePath).not.toHaveBeenCalled()
+
+    await expect(response.json()).resolves.toMatchObject({
+      revalidated: true,
+      tags: ["prismic"],
+      paths: [],
+    })
+  })
+
+  it("revalidates unique tags and paths from the request body", async () => {
+    vi.stubEnv("REVALIDATE_SECRET", "top-secret")
+
+    const response = await POST(
+      new Request("http://localhost/api/revalidate", {
+        method: "POST",
+        body: JSON.stringify({
+          secret: "top-secret",
+          tags: [" bolao:123 ", "players:123", "bolao:123"],
+          paths: ["/", "/bolao/123/results", "/"],
+        }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(revalidateTag).toHaveBeenCalledTimes(2)
+    expect(revalidateTag).toHaveBeenNthCalledWith(1, "bolao:123", {
+      expire: 0,
+    })
+    expect(revalidateTag).toHaveBeenNthCalledWith(2, "players:123", {
+      expire: 0,
+    })
+    expect(revalidatePath).toHaveBeenCalledTimes(2)
+    expect(revalidatePath).toHaveBeenNthCalledWith(1, "/")
+    expect(revalidatePath).toHaveBeenNthCalledWith(2, "/bolao/123/results")
+
+    await expect(response.json()).resolves.toMatchObject({
+      revalidated: true,
+      tags: ["bolao:123", "players:123"],
+      paths: ["/", "/bolao/123/results"],
+    })
+  })
+})

--- a/app/api/revalidate/__tests__/route.test.ts
+++ b/app/api/revalidate/__tests__/route.test.ts
@@ -28,6 +28,9 @@ describe("api/revalidate route", () => {
     )
 
     expect(response.status).toBe(500)
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-store, max-age=0"
+    )
     await expect(response.json()).resolves.toEqual({
       error: "REVALIDATE_SECRET is not configured.",
     })
@@ -44,6 +47,9 @@ describe("api/revalidate route", () => {
     )
 
     expect(response.status).toBe(401)
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-store, max-age=0"
+    )
     await expect(response.json()).resolves.toEqual({
       error: "Unauthorized.",
     })
@@ -62,6 +68,9 @@ describe("api/revalidate route", () => {
     )
 
     expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-store, max-age=0"
+    )
     expect(revalidateTag).toHaveBeenCalledWith("prismic", { expire: 0 })
     expect(revalidatePath).not.toHaveBeenCalled()
 
@@ -87,6 +96,9 @@ describe("api/revalidate route", () => {
     )
 
     expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-store, max-age=0"
+    )
     expect(revalidateTag).toHaveBeenCalledTimes(2)
     expect(revalidateTag).toHaveBeenNthCalledWith(1, "bolao:123", {
       expire: 0,

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,6 +1,8 @@
 import { revalidatePath, revalidateTag } from "next/cache"
 import { NextResponse } from "next/server"
 
+import { applyNoStoreHeaders } from "../cacheHeaders"
+
 type RevalidateRequestBody = {
   secret?: string
   tags?: string[]
@@ -34,9 +36,11 @@ export async function POST(request: Request) {
   const expectedSecret = process.env.REVALIDATE_SECRET
 
   if (!expectedSecret) {
-    return NextResponse.json(
-      { error: "REVALIDATE_SECRET is not configured." },
-      { status: 500 }
+    return applyNoStoreHeaders(
+      NextResponse.json(
+        { error: "REVALIDATE_SECRET is not configured." },
+        { status: 500 }
+      )
     )
   }
 
@@ -44,7 +48,9 @@ export async function POST(request: Request) {
     request.headers.get("x-revalidate-secret") || body.secret || ""
 
   if (providedSecret !== expectedSecret) {
-    return NextResponse.json({ error: "Unauthorized." }, { status: 401 })
+    return applyNoStoreHeaders(
+      NextResponse.json({ error: "Unauthorized." }, { status: 401 })
+    )
   }
 
   const tags = normalizeStringArray(body.tags)
@@ -54,10 +60,12 @@ export async function POST(request: Request) {
   tagsToRevalidate.forEach(expireTag)
   paths.forEach((path) => revalidatePath(path))
 
-  return NextResponse.json({
-    revalidated: true,
-    now: Date.now(),
-    tags: tagsToRevalidate,
-    paths,
-  })
+  return applyNoStoreHeaders(
+    NextResponse.json({
+      revalidated: true,
+      now: Date.now(),
+      tags: tagsToRevalidate,
+      paths,
+    })
+  )
 }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,8 +1,63 @@
-import { NextResponse } from "next/server";
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache"
+import { NextResponse } from "next/server"
 
-export async function POST() {
-  revalidateTag("prismic", { expire: 0 });
+type RevalidateRequestBody = {
+  secret?: string
+  tags?: string[]
+  paths?: string[]
+}
 
-  return NextResponse.json({ revalidated: true, now: Date.now() });
+const DEFAULT_TAGS = ["prismic"]
+
+function expireTag(tag: string) {
+  revalidateTag(tag, { expire: 0 })
+}
+
+function normalizeStringArray(values?: string[]) {
+  if (!values) {
+    return []
+  }
+
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))]
+}
+
+async function parseBody(request: Request): Promise<RevalidateRequestBody> {
+  try {
+    return await request.json()
+  } catch {
+    return {}
+  }
+}
+
+export async function POST(request: Request) {
+  const body = await parseBody(request)
+  const expectedSecret = process.env.REVALIDATE_SECRET
+
+  if (!expectedSecret) {
+    return NextResponse.json(
+      { error: "REVALIDATE_SECRET is not configured." },
+      { status: 500 }
+    )
+  }
+
+  const providedSecret =
+    request.headers.get("x-revalidate-secret") || body.secret || ""
+
+  if (providedSecret !== expectedSecret) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 })
+  }
+
+  const tags = normalizeStringArray(body.tags)
+  const paths = normalizeStringArray(body.paths)
+  const tagsToRevalidate = tags.length > 0 ? tags : DEFAULT_TAGS
+
+  tagsToRevalidate.forEach(expireTag)
+  paths.forEach((path) => revalidatePath(path))
+
+  return NextResponse.json({
+    revalidated: true,
+    now: Date.now(),
+    tags: tagsToRevalidate,
+    paths,
+  })
 }

--- a/app/components/__tests__/header.test.tsx
+++ b/app/components/__tests__/header.test.tsx
@@ -3,19 +3,8 @@ import { render } from "@testing-library/react"
 import { vi } from "vitest"
 import Header from "../header"
 
-// Mock Clerk auth
-const mockAuth = vi.fn()
-vi.mock("@clerk/nextjs/server", () => ({
-  auth: () => mockAuth(),
-}))
-
-// Mock Clerk UserButton
-vi.mock("@clerk/nextjs", () => ({
-  UserButton: () => <div data-testid="user-button">User Button</div>,
-}))
-
-// Mock UserButtonWrapper component
-vi.mock("../userButtonWrapper", () => ({
+// Mock HeaderUserActions component
+vi.mock("../headerUserActions", () => ({
   default: () => <div data-testid="user-button">User Button</div>,
 }))
 
@@ -29,11 +18,8 @@ vi.mock("../logoSvg", () => ({
 }))
 
 describe("Header", () => {
-  it("should render logo link", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-
-    const HeaderComponent = await Header()
-    render(HeaderComponent)
+  it("should render logo link", () => {
+    render(<Header />)
 
     const logoLink = screen.getByTestId("logo-link-header")
     expect(logoLink).toBeInTheDocument()
@@ -42,32 +28,17 @@ describe("Header", () => {
     expect(logoLink.className).toContain("transition-colors")
   })
 
-  it("should render LogoSvg with correct props", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-
-    const HeaderComponent = await Header()
-    render(HeaderComponent)
+  it("should render LogoSvg with correct props", () => {
+    render(<Header />)
 
     const logoSvg = screen.getByTestId("logo-svg")
     expect(logoSvg).toBeInTheDocument()
     expect(logoSvg).toHaveAttribute("data-size", "80")
   })
 
-  it("should render UserButton when user is authenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: "user123" })
-
-    const HeaderComponent = await Header()
-    render(HeaderComponent)
+  it("should render header user actions", () => {
+    render(<Header />)
 
     expect(screen.getByTestId("user-button")).toBeInTheDocument()
-  })
-
-  it("should not render UserButton when user is not authenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-
-    const HeaderComponent = await Header()
-    render(HeaderComponent)
-
-    expect(screen.queryByTestId("user-button")).not.toBeInTheDocument()
   })
 })

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,13 +1,10 @@
-import { auth } from "@clerk/nextjs/server"
 import Link from "next/link"
 
 import LogoSvg from "./logoSvg"
 import BackgroundStripes from "./backgroundStripes"
-import UserButtonWrapper from "./userButtonWrapper"
+import HeaderUserActions from "./headerUserActions"
 
-async function Header() {
-  const { userId }: { userId: string | null } = await auth()
-
+function Header() {
   return (
     <header>
       <BackgroundStripes />
@@ -21,7 +18,9 @@ async function Header() {
             <LogoSvg size={80} />
           </Link>
         </div>
-        <div className="content-center">{userId && <UserButtonWrapper />}</div>
+        <div className="content-center">
+          <HeaderUserActions />
+        </div>
       </div>
     </header>
   )

--- a/app/components/headerUserActions.tsx
+++ b/app/components/headerUserActions.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import { SignedIn } from "@clerk/nextjs"
+
+import UserButtonWrapper from "./userButtonWrapper"
+
+export default function HeaderUserActions() {
+  return (
+    <SignedIn>
+      <UserButtonWrapper />
+    </SignedIn>
+  )
+}

--- a/app/components/homeHeroActions.tsx
+++ b/app/components/homeHeroActions.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import Link from "next/link"
+import { SignedIn, SignedOut } from "@clerk/nextjs"
+
+import { Button } from "@/components/ui/button"
+
+type HomeHeroActionsProps = {
+  getStartedLabel: string
+  loginLabel: string
+  dashboardLabel: string
+  createBolaoLabel: string
+}
+
+export default function HomeHeroActions({
+  getStartedLabel,
+  loginLabel,
+  dashboardLabel,
+  createBolaoLabel,
+}: HomeHeroActionsProps) {
+  return (
+    <div className="flex items-center justify-center gap-4 mb-4">
+      <SignedOut>
+        <Button asChild>
+          <Link href="/sign-up">{getStartedLabel}</Link>
+        </Button>
+        <Button asChild variant="secondary">
+          <Link href="/sign-in">{loginLabel}</Link>
+        </Button>
+      </SignedOut>
+
+      <SignedIn>
+        <Button asChild>
+          <Link href="/dashboard">{dashboardLabel}</Link>
+        </Button>
+        <Button asChild variant="secondary">
+          <Link href="/bolao/create">{createBolaoLabel}</Link>
+        </Button>
+      </SignedIn>
+    </div>
+  )
+}

--- a/app/dashboard/__tests__/page.test.tsx
+++ b/app/dashboard/__tests__/page.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import Dashboard from "../page"
+
+const mockCurrentUser = vi.fn()
+const mockRedirect = vi.fn()
+
+vi.mock("@clerk/nextjs/server", () => ({
+  currentUser: () => mockCurrentUser(),
+}))
+
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => mockRedirect(path),
+}))
+
+vi.mock("@/app/components/pageTitle", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="page-title">{children}</div>
+  ),
+}))
+
+vi.mock("@/app/components/InviteRedirector", () => ({
+  default: () => <div data-testid="invite-redirector" />,
+}))
+
+vi.mock("@/app/ui/home/boloesList", () => ({
+  default: () => <div data-testid="boloes-list">BoloesList Component</div>,
+}))
+
+vi.mock("@/app/ui/skeletons", () => ({
+  BoloesListSkeleton: () => <div data-testid="skeleton">Loading...</div>,
+}))
+
+describe("Dashboard Page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("redirects unauthenticated users to sign-in", async () => {
+    mockCurrentUser.mockResolvedValue(null)
+
+    render(await Dashboard())
+
+    expect(mockRedirect).toHaveBeenCalledWith("/sign-in")
+  })
+
+  it("renders the greeting with username when available", async () => {
+    mockCurrentUser.mockResolvedValue({
+      username: "johndoe",
+      emailAddresses: [{ emailAddress: "john@example.com" }],
+    })
+
+    render(await Dashboard())
+
+    expect(screen.getByText("Hey")).toBeInTheDocument()
+    expect(screen.getByText("johndoe.")).toBeInTheDocument()
+    expect(screen.getByTestId("boloes-list")).toBeInTheDocument()
+  })
+
+  it("falls back to the email prefix when username is missing", async () => {
+    mockCurrentUser.mockResolvedValue({
+      username: null,
+      emailAddresses: [{ emailAddress: "jane@example.com" }],
+    })
+
+    render(await Dashboard())
+
+    expect(screen.getByText("jane")).toBeInTheDocument()
+  })
+
+  it("keeps invite redirector and page title in the dashboard shell", async () => {
+    mockCurrentUser.mockResolvedValue({
+      username: "testuser",
+      emailAddresses: [{ emailAddress: "test@example.com" }],
+    })
+
+    render(await Dashboard())
+
+    expect(screen.getByTestId("invite-redirector")).toBeInTheDocument()
+    expect(screen.getByTestId("page-title")).toBeInTheDocument()
+  })
+})

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from "react"
+import { currentUser } from "@clerk/nextjs/server"
+import { redirect } from "next/navigation"
+import { getTranslations } from "next-intl/server"
+
+import InviteRedirector from "@/app/components/InviteRedirector"
+import PageTitle from "@/app/components/pageTitle"
+import BoloesList from "@/app/ui/home/boloesList"
+import { BoloesListSkeleton } from "@/app/ui/skeletons"
+
+export default async function Dashboard() {
+  const user = await currentUser()
+  const t = await getTranslations("home")
+
+  if (!user) {
+    redirect("/sign-in")
+    return null
+  }
+
+  return (
+    <main>
+      <InviteRedirector />
+      <PageTitle>
+        {t("greeting")}
+        <br />
+        <span className="font-bold">
+          {user.username
+            ? `${user.username}.`
+            : user.emailAddresses[0].emailAddress.split("@")[0]}
+        </span>
+      </PageTitle>
+
+      <Suspense fallback={<BoloesListSkeleton />}>
+        <BoloesList />
+      </Suspense>
+    </main>
+  )
+}

--- a/app/lib/__tests__/actions.test.ts
+++ b/app/lib/__tests__/actions.test.ts
@@ -13,6 +13,7 @@ vi.mock("next/navigation", () => ({
 // Mock next/cache
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
 }))
 
 // Mock @clerk/nextjs/server
@@ -44,7 +45,7 @@ import {
 } from "../actions"
 import { sql } from "@vercel/postgres"
 import { redirect } from "next/navigation"
-import { revalidatePath } from "next/cache"
+import { revalidatePath, revalidateTag } from "next/cache"
 import { auth } from "@clerk/nextjs/server"
 import { fetchLeague } from "../data"
 import { getCurrentSeasonObject } from "../utils"

--- a/app/lib/__tests__/controllerBet.test.ts
+++ b/app/lib/__tests__/controllerBet.test.ts
@@ -10,6 +10,14 @@ vi.mock("@/app/lib/data", () => ({
   fetchRounds: vi.fn(),
   fetchFixtures: vi.fn(),
   fetchUserBets: vi.fn(),
+  fetchPlayersForBolao: vi.fn(async ({ usersBolao }) =>
+    usersBolao.map((userBolao: { id: string; user_id: string }) => ({
+      id: userBolao.user_id,
+      username: null,
+      email: `${userBolao.user_id}@example.com`,
+      userBolaoId: userBolao.id,
+    }))
+  ),
 }))
 
 vi.mock("@clerk/nextjs/server", () => ({
@@ -171,8 +179,8 @@ describe("controllerBet", () => {
         fetchRounds,
         fetchFixtures,
         fetchUserBets,
+        fetchPlayersForBolao,
       } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
@@ -183,24 +191,20 @@ describe("controllerBet", () => {
       vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
-      vi.mocked(clerkClient).mockResolvedValue({
-        users: {
-          getUserList: vi.fn().mockResolvedValue({
-            data: [
-              {
-                id: "user-1",
-                username: "kevin",
-                emailAddresses: [{ emailAddress: "kevin@example.com" }],
-              },
-              {
-                id: "user-2",
-                username: "other",
-                emailAddresses: [{ emailAddress: "other@example.com" }],
-              },
-            ],
-          }),
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([
+        {
+          id: "user-1",
+          username: "kevin",
+          email: "kevin@example.com",
+          userBolaoId: "ub-1",
         },
-      } as any)
+        {
+          id: "user-2",
+          username: "other",
+          email: "other@example.com",
+          userBolaoId: "ub-2",
+        },
+      ])
 
       const result = await getData({
         bolaoId: "bolao-1",
@@ -235,8 +239,8 @@ describe("controllerBet", () => {
         fetchRounds,
         fetchFixtures,
         fetchUserBets,
+        fetchPlayersForBolao,
       } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
@@ -247,11 +251,7 @@ describe("controllerBet", () => {
       vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
-      vi.mocked(clerkClient).mockResolvedValue({
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      } as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([])
 
       const result = await getData({
         bolaoId: "bolao-1",
@@ -272,8 +272,8 @@ describe("controllerBet", () => {
         fetchRounds,
         fetchFixtures,
         fetchUserBets,
+        fetchPlayersForBolao,
       } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
@@ -284,11 +284,7 @@ describe("controllerBet", () => {
       vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
-      vi.mocked(clerkClient).mockResolvedValue({
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      } as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([])
 
       const result = await getData({
         bolaoId: "bolao-1",

--- a/app/lib/__tests__/controllerLead.test.ts
+++ b/app/lib/__tests__/controllerLead.test.ts
@@ -14,11 +14,7 @@ vi.mock("@/app/lib/data", () => ({
   fetchUsersBolao: vi.fn(),
   fetchFixtures: vi.fn(),
   fetchUsersBets: vi.fn(),
-}))
-
-// Mock Clerk client
-vi.mock("@clerk/nextjs/server", () => ({
-  clerkClient: vi.fn(),
+  fetchPlayersForBolao: vi.fn().mockResolvedValue([]),
 }))
 
 describe("controllerLead", () => {
@@ -88,38 +84,40 @@ describe("controllerLead", () => {
     },
   ]
 
+  const mockPlayers: PlayersData[] = [
+    {
+      id: "user-1",
+      username: null,
+      email: "john@example.com",
+      userBolaoId: "ub-1",
+    },
+    {
+      id: "user-2",
+      username: null,
+      email: "jane@example.com",
+      userBolaoId: "ub-2",
+    },
+  ]
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe("getData", () => {
     it("should fetch and return all required data", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
-        await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockClient = {
-        users: {
-          getUserList: vi.fn().mockResolvedValue({
-            data: [
-              {
-                id: "user-1",
-                emailAddresses: [{ emailAddress: "john@example.com" }],
-              },
-              {
-                id: "user-2",
-                emailAddresses: [{ emailAddress: "jane@example.com" }],
-              },
-            ],
-          }),
-        },
-      }
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchPlayersForBolao,
+      } = await import("@/app/lib/data")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue(mockUsersBolao as any)
       vi.mocked(fetchFixtures).mockResolvedValue([mockFixture])
       vi.mocked(fetchUsersBets).mockResolvedValue(mockBets)
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue(mockPlayers)
 
       const result = await getData({ bolaoId: "bolao-1" })
 
@@ -130,21 +128,19 @@ describe("controllerLead", () => {
     })
 
     it("should fetch bolao and usersBolao in parallel", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
-        await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockClient = {
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      }
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchPlayersForBolao,
+      } = await import("@/app/lib/data")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([])
 
       await getData({ bolaoId: "bolao-1" })
 
@@ -152,67 +148,43 @@ describe("controllerLead", () => {
       expect(fetchUsersBolao).toHaveBeenCalledWith("bolao-1")
     })
 
-    it("should fetch players from Clerk with correct user IDs", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
-        await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockGetUserList = vi.fn().mockResolvedValue({
-        data: [
-          {
-            id: "user-1",
-            username: null,
-            emailAddresses: [{ emailAddress: "user1@example.com" }],
-          },
-          {
-            id: "user-2",
-            username: null,
-            emailAddresses: [{ emailAddress: "user2@example.com" }],
-          },
-        ],
-      })
-
-      const mockClient = {
-        users: { getUserList: mockGetUserList },
-      }
+    it("should fetch players with the bolao membership payload", async () => {
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchPlayersForBolao,
+      } = await import("@/app/lib/data")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue(mockUsersBolao as any)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue(mockPlayers)
 
       await getData({ bolaoId: "bolao-1" })
 
-      expect(mockGetUserList).toHaveBeenCalledWith({
-        userId: ["user-1", "user-2"],
+      expect(fetchPlayersForBolao).toHaveBeenCalledWith({
+        bolaoId: "bolao-1",
+        usersBolao: mockUsersBolao,
       })
     })
 
     it("should map players correctly with userBolaoId", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
-        await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockClient = {
-        users: {
-          getUserList: vi.fn().mockResolvedValue({
-            data: [
-              {
-                id: "user-1",
-                username: null,
-                emailAddresses: [{ emailAddress: "john@example.com" }],
-              },
-            ],
-          }),
-        },
-      }
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchPlayersForBolao,
+      } = await import("@/app/lib/data")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue([mockUsersBolao[0]] as any)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([mockPlayers[0]])
 
       const result = await getData({ bolaoId: "bolao-1" })
 
@@ -225,21 +197,19 @@ describe("controllerLead", () => {
     })
 
     it("should fetch fixtures with correct parameters", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
-        await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockClient = {
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      }
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchPlayersForBolao,
+      } = await import("@/app/lib/data")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([])
 
       await getData({ bolaoId: "bolao-1" })
 
@@ -250,21 +220,19 @@ describe("controllerLead", () => {
     })
 
     it("should fetch bets with all userBolao IDs", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
-        await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockClient = {
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      }
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchPlayersForBolao,
+      } = await import("@/app/lib/data")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue(mockUsersBolao as any)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([])
 
       await getData({ bolaoId: "bolao-1" })
 
@@ -272,15 +240,13 @@ describe("controllerLead", () => {
     })
 
     it("should handle multiple fixtures", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
-        await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockClient = {
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      }
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchPlayersForBolao,
+      } = await import("@/app/lib/data")
 
       const fixtures = [
         mockFixture,
@@ -292,7 +258,7 @@ describe("controllerLead", () => {
       vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
       vi.mocked(fetchFixtures).mockResolvedValue(fixtures)
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([])
 
       const result = await getData({ bolaoId: "bolao-1" })
 
@@ -310,17 +276,17 @@ describe("controllerLead", () => {
       )
     })
 
-    it("should propagate errors from Clerk client", async () => {
-      const { fetchBolao, fetchUsersBolao } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-      const error = new Error("Clerk API error")
+    it("should propagate errors from player fetching", async () => {
+      const { fetchBolao, fetchUsersBolao, fetchPlayersForBolao } =
+        await import("@/app/lib/data")
+      const error = new Error("Player fetch error")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue(mockUsersBolao as any)
-      vi.mocked(clerkClient).mockRejectedValue(error)
+      vi.mocked(fetchPlayersForBolao).mockRejectedValue(error)
 
       await expect(getData({ bolaoId: "bolao-1" })).rejects.toThrow(
-        "Clerk API error"
+        "Player fetch error"
       )
     })
   })

--- a/app/lib/__tests__/controllerResults.test.ts
+++ b/app/lib/__tests__/controllerResults.test.ts
@@ -9,6 +9,14 @@ vi.mock("@/app/lib/data", () => ({
   fetchRounds: vi.fn(),
   fetchFixtures: vi.fn(),
   fetchUsersBets: vi.fn(),
+  fetchPlayersForBolao: vi.fn(async ({ usersBolao }) =>
+    usersBolao.map((userBolao: { id: string; user_id: string }) => ({
+      id: userBolao.user_id,
+      username: null,
+      email: `${userBolao.user_id}@example.com`,
+      userBolaoId: userBolao.id,
+    }))
+  ),
 }))
 
 // Mock Clerk client
@@ -95,8 +103,18 @@ describe("controllerResults", () => {
 
   const mockRounds = ["Round 1", "Round 2", "Round 3", "Round 4"]
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
+
+    const { fetchPlayersForBolao } = await import("@/app/lib/data")
+    vi.mocked(fetchPlayersForBolao).mockImplementation(async ({ usersBolao }) =>
+      usersBolao.map((userBolao: { id: string; user_id: string }) => ({
+        id: userBolao.user_id,
+        username: null,
+        email: `${userBolao.user_id}@example.com`,
+        userBolaoId: userBolao.id,
+      }))
+    )
   })
 
   describe("getData", () => {
@@ -425,46 +443,27 @@ describe("controllerResults", () => {
       expect(result.currentRound).toBe("Round 4") // Last round
     })
 
-    it("should fetch players from Clerk with correct user IDs", async () => {
+    it("should fetch players with the bolao membership payload", async () => {
       const {
         fetchBolao,
         fetchUsersBolao,
         fetchRounds,
         fetchFixtures,
         fetchUsersBets,
+        fetchPlayersForBolao,
       } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockGetUserList = vi.fn().mockResolvedValue({
-        data: [
-          {
-            id: "user-1",
-            username: null,
-            emailAddresses: [{ emailAddress: "user1@example.com" }],
-          },
-          {
-            id: "user-2",
-            username: null,
-            emailAddresses: [{ emailAddress: "user2@example.com" }],
-          },
-        ],
-      })
-
-      const mockClient = {
-        users: { getUserList: mockGetUserList },
-      }
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue(mockUsersBolao as any)
       vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
 
       await getData({ bolaoId: "bolao-1" })
 
-      expect(mockGetUserList).toHaveBeenCalledWith({
-        userId: ["user-1", "user-2"],
+      expect(fetchPlayersForBolao).toHaveBeenCalledWith({
+        bolaoId: "bolao-1",
+        usersBolao: mockUsersBolao,
       })
     })
 
@@ -475,29 +474,22 @@ describe("controllerResults", () => {
         fetchRounds,
         fetchFixtures,
         fetchUsersBets,
+        fetchPlayersForBolao,
       } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      const mockClient = {
-        users: {
-          getUserList: vi.fn().mockResolvedValue({
-            data: [
-              {
-                id: "user-1",
-                username: null,
-                emailAddresses: [{ emailAddress: "john@example.com" }],
-              },
-            ],
-          }),
-        },
-      }
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue([mockUsersBolao[0]] as any)
       vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
       vi.mocked(fetchFixtures).mockResolvedValue([])
       vi.mocked(fetchUsersBets).mockResolvedValue([])
-      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchPlayersForBolao).mockResolvedValue([
+        {
+          id: "user-1",
+          username: null,
+          email: "john@example.com",
+          userBolaoId: "ub-1",
+        },
+      ])
 
       const result = await getData({ bolaoId: "bolao-1" })
 
@@ -610,19 +602,18 @@ describe("controllerResults", () => {
       )
     })
 
-    it("should propagate errors from Clerk client", async () => {
-      const { fetchBolao, fetchUsersBolao, fetchRounds } =
+    it("should propagate errors from player fetching", async () => {
+      const { fetchBolao, fetchUsersBolao, fetchRounds, fetchPlayersForBolao } =
         await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-      const error = new Error("Clerk API error")
+      const error = new Error("Player fetch error")
 
       vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
       vi.mocked(fetchUsersBolao).mockResolvedValue(mockUsersBolao as any)
       vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(clerkClient).mockRejectedValue(error)
+      vi.mocked(fetchPlayersForBolao).mockRejectedValue(error)
 
       await expect(getData({ bolaoId: "bolao-1" })).rejects.toThrow(
-        "Clerk API error"
+        "Player fetch error"
       )
     })
 

--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -1,11 +1,16 @@
 "use server"
 
 import { sql } from "@vercel/postgres"
-import { revalidatePath } from "next/cache"
+import { revalidatePath, revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
 import { auth } from "@clerk/nextjs/server"
 import { fetchLeague } from "./data"
 import { getCurrentSeasonObject } from "./utils"
+import { cacheTags } from "./cache"
+
+function expireTag(tag: string) {
+  revalidateTag(tag, { expire: 0 })
+}
 import {
   BetResult,
   UpdateBolaoResult,
@@ -74,6 +79,10 @@ export async function createBolao(
     const userBolaoResult = await createUserBolao(insertedData.id)
 
     if (userBolaoResult.success) {
+      expireTag(cacheTags.bolao(insertedData.id))
+      expireTag(cacheTags.players(insertedData.id))
+      revalidatePath("/")
+
       return {
         success: true,
       }
@@ -109,6 +118,7 @@ export async function updateBolao({
       success: true,
     }
 
+    expireTag(cacheTags.bolao(bolaoId))
     revalidatePath("/")
 
     return result
@@ -139,6 +149,10 @@ export async function createUserBolao(
       user_id: data.rows[0].user_id,
       success: true,
     }
+
+    expireTag(cacheTags.bolao(String(bolaoId)))
+    expireTag(cacheTags.players(String(bolaoId)))
+    revalidatePath("/")
 
     return result
   } catch (error) {
@@ -213,6 +227,8 @@ export async function deleteBolao(bolaoId: string) {
 
     const data = result.rows
 
+    expireTag(cacheTags.bolao(bolaoId))
+    expireTag(cacheTags.players(bolaoId))
     revalidatePath("/")
 
     return {

--- a/app/lib/cache.ts
+++ b/app/lib/cache.ts
@@ -1,0 +1,44 @@
+const MINUTE = 60
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+export const CACHE_REVALIDATE = {
+  league: 7 * DAY,
+  rounds: 12 * HOUR,
+  fixtures: 5 * MINUTE,
+  fixturesAll: HOUR,
+  standings: 10 * MINUTE,
+  bolao: HOUR,
+  players: HOUR,
+} as const
+
+export const cacheTags = {
+  bolao: (bolaoId: string) => `bolao:${bolaoId}`,
+  players: (bolaoId: string) => `players:${bolaoId}`,
+  league: (leagueId: string | number) => `league:${leagueId}`,
+  rounds: ({
+    leagueId,
+    year,
+    current = false,
+  }: {
+    leagueId: string | number
+    year: number
+    current?: boolean
+  }) => `rounds:${leagueId}:${year}${current ? ":current" : ""}`,
+  fixtures: ({
+    leagueId,
+    year,
+    round,
+  }: {
+    leagueId: string | number
+    year: number
+    round?: string
+  }) => `fixtures:${leagueId}:${year}:${round || "all"}`,
+  standings: ({
+    leagueId,
+    year,
+  }: {
+    leagueId: string | number
+    year: number
+  }) => `standings:${leagueId}:${year}`,
+} as const

--- a/app/lib/controllerBet.ts
+++ b/app/lib/controllerBet.ts
@@ -5,6 +5,7 @@ import {
   fetchRounds,
   fetchFixtures,
   fetchUserBets,
+  fetchPlayersForBolao,
 } from "@/app/lib/data"
 import {
   sortFixtures,
@@ -12,26 +13,6 @@ import {
   pickCurrentRoundFromApiCurrent,
 } from "@/app/lib/utils"
 import { Bet, PlayersData, UserBolao } from "@/app/lib/definitions"
-import { clerkClient } from "@clerk/nextjs/server"
-
-async function getPlayers(usersBolao: UserBolao[]) {
-  const userIds: string[] = usersBolao.map((el: UserBolao) => el.user_id)
-  const client = await clerkClient()
-  const users = await client.users.getUserList({ userId: userIds })
-
-  return users.data.map((el) => {
-    const userBolaoObj = usersBolao.find(
-      (ub: UserBolao) => ub.user_id === el.id
-    )
-
-    return {
-      id: el.id,
-      username: el.username,
-      email: el.emailAddresses[0]?.emailAddress || "",
-      userBolaoId: userBolaoObj?.id || "",
-    }
-  })
-}
 
 export async function getData({
   bolaoId,
@@ -59,7 +40,7 @@ export async function getData({
 
   if (isAdmin) {
     const usersBolao: UserBolao[] = await fetchUsersBolao(bolaoId)
-    players = await getPlayers(usersBolao)
+    players = await fetchPlayersForBolao({ bolaoId, usersBolao })
 
     selectedUserBolao =
       usersBolao.find((el) => el.id === selectedUserBolaoId) || userBolao

--- a/app/lib/controllerLead.ts
+++ b/app/lib/controllerLead.ts
@@ -3,9 +3,9 @@ import {
   fetchUsersBolao,
   fetchFixtures,
   fetchUsersBets,
+  fetchPlayersForBolao,
 } from "@/app/lib/data"
 import { FixtureData, UserBolao, PlayersData, Bet } from "./definitions"
-import { clerkClient } from "@clerk/nextjs/server"
 
 export async function getData({ bolaoId }: { bolaoId: string }) {
   const [bolao, usersBolao] = await Promise.all([
@@ -16,34 +16,14 @@ export async function getData({ bolaoId }: { bolaoId: string }) {
   const year: number = bolao.year
   const leagueId: string = bolao.competition_id
 
-  // Fetch players infos
-  const userIds: string[] = usersBolao.map((el: UserBolao) => el.user_id)
-  const client = await clerkClient()
-  const users = await client.users.getUserList({ userId: userIds })
-
-  const players: PlayersData[] = []
-  users.data.map((el) => {
-    // TODO: fix the "any" type
-    const userBolaoObj: any = usersBolao.find(
-      (ub: UserBolao) => ub.user_id === el.id
-    )
-
-    const obj = {
-      id: el.id,
-      username: el.username,
-      email: el.emailAddresses[0].emailAddress,
-      userBolaoId: userBolaoObj.id,
-    }
-
-    players.push(obj)
-  })
-
-  // Fetch all fixtures
-  const fixtures: FixtureData[] = await fetchFixtures({ leagueId, year })
-
-  // Fetch bets
   const userBoloesIds: string[] = usersBolao.map((el: UserBolao) => el.id)
-  const bets: Bet[] = await fetchUsersBets(userBoloesIds)
+
+  const [players, fixtures, bets]: [PlayersData[], FixtureData[], Bet[]] =
+    await Promise.all([
+      fetchPlayersForBolao({ bolaoId, usersBolao }),
+      fetchFixtures({ leagueId, year }),
+      fetchUsersBets(userBoloesIds),
+    ])
 
   return {
     bolao,

--- a/app/lib/controllerResults.ts
+++ b/app/lib/controllerResults.ts
@@ -4,6 +4,7 @@ import {
   fetchRounds,
   fetchFixtures,
   fetchUsersBets,
+  fetchPlayersForBolao,
 } from "@/app/lib/data"
 import {
   sortFixtures,
@@ -11,7 +12,6 @@ import {
   pickCurrentRoundFromApiCurrent,
 } from "@/app/lib/utils"
 import { Bet, UserBolao, PlayersData } from "@/app/lib/definitions"
-import { clerkClient } from "@clerk/nextjs/server"
 
 export async function getData({
   bolaoId,
@@ -28,41 +28,24 @@ export async function getData({
   const year: number = bolao.year
   const leagueId: string = bolao.competition_id
 
-  // Fetch players infos
-  const userIds: string[] = usersBolao.map((el: UserBolao) => el.user_id)
-  const client = await clerkClient()
-  const users = await client.users.getUserList({ userId: userIds })
-
-  const players: PlayersData[] = []
-  users.data.map((el) => {
-    // TODO: fix the "any" type
-    const userBolaoObj: any = usersBolao.find(
-      (ub: UserBolao) => ub.user_id === el.id
-    )
-
-    const obj = {
-      id: el.id,
-      username: el.username,
-      email: el.emailAddresses[0].emailAddress,
-      userBolaoId: userBolaoObj.id,
-    }
-
-    players.push(obj)
-  })
-
-  // Fetch bets
   const userBoloesIds: string[] = usersBolao.map((el: UserBolao) => el.id)
-  const bets: Bet[] = await fetchUsersBets(userBoloesIds)
+  const [players, bets, allRoundsUncleaned, currentRoundObj]: [
+    PlayersData[],
+    Bet[],
+    string[],
+    string[],
+  ] = await Promise.all([
+    fetchPlayersForBolao({ bolaoId, usersBolao }),
+    fetchUsersBets(userBoloesIds),
+    fetchRounds({ leagueId, year }),
+    fetchRounds({
+      leagueId,
+      year,
+      current: true,
+    }),
+  ])
 
-  // Fetch rounds infos
-  const allRoundsUncleaned: string[] = await fetchRounds({ leagueId, year })
   const allRounds: string[] = cleanRounds(allRoundsUncleaned)
-
-  const currentRoundObj: string[] = await fetchRounds({
-    leagueId,
-    year,
-    current: true,
-  })
 
   const currentRound = pickCurrentRoundFromApiCurrent(
     currentRoundObj,

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -2,9 +2,54 @@
 
 import { QueryResultRow } from "pg"
 import { sql } from "@vercel/postgres"
+import { clerkClient } from "@clerk/nextjs/server"
+import { unstable_cache } from "next/cache"
 import { FOOTBALL_API_SPORTS } from "./utils"
-import { Bolao, Bet, User } from "./definitions"
+import { Bolao, Bet, User, UserBolao, PlayersData } from "./definitions"
 import { FOOTBALL_API_SPORTS_LEAGUES } from "./utils"
+import { CACHE_REVALIDATE, cacheTags } from "./cache"
+
+type CachedPlayer = {
+  id: string
+  username: string | null
+  email: string
+}
+
+function getFootballHeaders(token: string) {
+  return {
+    "x-rapidapi-key": token,
+    "x-rapidapi-host": "v3.football.api-sports.io",
+  }
+}
+
+function createBolaoCacheKey(prefix: string, bolaoId: string) {
+  return [prefix, bolaoId]
+}
+
+async function fetchCachedClerkUsers(
+  bolaoId: string,
+  userIds: string[]
+): Promise<CachedPlayer[]> {
+  const normalizedUserIds = [...userIds].sort()
+
+  return unstable_cache(
+    async () => {
+      const client = await clerkClient()
+      const users = await client.users.getUserList({ userId: normalizedUserIds })
+
+      return users.data.map((user) => ({
+        id: user.id,
+        username: user.username,
+        email: user.emailAddresses[0]?.emailAddress || "",
+      }))
+    },
+    ["players", bolaoId, normalizedUserIds.join(":")],
+    {
+      revalidate: CACHE_REVALIDATE.players,
+      tags: [cacheTags.players(bolaoId)],
+    }
+  )()
+}
 
 export async function fetchBoloes() {
   try {
@@ -43,27 +88,36 @@ export async function fetchBoloesByUserId(userId: string) {
 
 export async function fetchBolao(bolaoId: string) {
   try {
-    const data: { rows: QueryResultRow[] } = await sql`SELECT *
-      FROM boloes
-      WHERE CAST(id AS VARCHAR) = ${bolaoId}
-    `
+    return await unstable_cache(
+      async () => {
+        const data: { rows: QueryResultRow[] } = await sql`SELECT *
+          FROM boloes
+          WHERE CAST(id AS VARCHAR) = ${bolaoId}
+        `
 
-    const row = data.rows[0]
+        const row = data.rows[0]
 
-    if (!row) {
-      throw new Error("No bolao found for the given ID.")
-    }
+        if (!row) {
+          throw new Error("No bolao found for the given ID.")
+        }
 
-    return {
-      id: row.id as string,
-      name: row.name as string,
-      competition_id: row.competition_id as string,
-      year: row.year as number,
-      start: row.start,
-      end: row.end,
-      created_by: row.created_by,
-      created_at: row.created_at,
-    }
+        return {
+          id: row.id as string,
+          name: row.name as string,
+          competition_id: row.competition_id as string,
+          year: row.year as number,
+          start: row.start,
+          end: row.end,
+          created_by: row.created_by,
+          created_at: row.created_at,
+        }
+      },
+      createBolaoCacheKey("bolao", bolaoId),
+      {
+        revalidate: CACHE_REVALIDATE.bolao,
+        tags: [cacheTags.bolao(bolaoId)],
+      }
+    )()
   } catch (error) {
     console.error("Database Error:", error)
     throw new Error("Failed to fetch bolao.")
@@ -113,21 +167,63 @@ export async function fetchUserBolao({
 
 export async function fetchUsersBolao(bolaoId: string) {
   try {
-    const data: { rows: QueryResultRow[] } = await sql`SELECT *
-      FROM user_bolao
-      WHERE CAST(bolao_id AS VARCHAR) = ${bolaoId}
-    `
+    return await unstable_cache(
+      async () => {
+        const data: { rows: QueryResultRow[] } = await sql`SELECT *
+          FROM user_bolao
+          WHERE CAST(bolao_id AS VARCHAR) = ${bolaoId}
+        `
 
-    const rows = data.rows
+        const rows = data.rows
 
-    if (!rows) {
-      throw new Error("No user bolões found for the given ID.")
-    }
+        if (!rows) {
+          throw new Error("No user bolões found for the given ID.")
+        }
 
-    return rows as []
+        return rows as UserBolao[]
+      },
+      createBolaoCacheKey("bolao-users", bolaoId),
+      {
+        revalidate: CACHE_REVALIDATE.bolao,
+        tags: [cacheTags.bolao(bolaoId)],
+      }
+    )()
   } catch (error) {
     console.error("Database Error:", error)
     throw new Error("Failed to fetch user bolões.")
+  }
+}
+
+export async function fetchPlayersForBolao({
+  bolaoId,
+  usersBolao,
+}: {
+  bolaoId: string
+  usersBolao: UserBolao[]
+}) {
+  if (usersBolao.length === 0) {
+    return [] as PlayersData[]
+  }
+
+  try {
+    const users = await fetchCachedClerkUsers(
+      bolaoId,
+      usersBolao.map((userBolao) => userBolao.user_id)
+    )
+
+    return users.map((user) => {
+      const userBolao = usersBolao.find((entry) => entry.user_id === user.id)
+
+      return {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        userBolaoId: userBolao?.id || "",
+      }
+    })
+  } catch (error) {
+    console.error("Clerk Error:", error)
+    throw new Error("Failed to fetch players.")
   }
 }
 
@@ -146,18 +242,16 @@ export async function fetchLeague(leagueId: number) {
     throw new Error("RAPID_API_KEY environment variable is not set")
   }
 
-  const myHeaders = new Headers()
-  myHeaders.append("x-rapidapi-key", token)
-  myHeaders.append("x-rapidapi-host", "v3.football.api-sports.io")
-
-  const requestOptions = {
-    method: "GET",
-    headers: myHeaders,
-  }
-
   const url = `${FOOTBALL_API_SPORTS}/leagues?id=${leagueId}`
 
-  const res = await fetch(url, requestOptions)
+  const res = await fetch(url, {
+    method: "GET",
+    headers: getFootballHeaders(token),
+    next: {
+      revalidate: CACHE_REVALIDATE.league,
+      tags: [cacheTags.league(leagueId)],
+    },
+  })
 
   if (!res.ok) {
     // This will activate the closest `error.js` Error Boundary
@@ -186,21 +280,19 @@ export async function fetchRounds({
     throw new Error("RAPID_API_KEY environment variable is not set")
   }
 
-  const myHeaders = new Headers()
-  myHeaders.append("x-rapidapi-key", token)
-  myHeaders.append("x-rapidapi-host", "v3.football.api-sports.io")
-
-  const requestOptions = {
-    method: "GET",
-    headers: myHeaders,
-  }
-
   let url = `${FOOTBALL_API_SPORTS}/fixtures/rounds?league=${leagueId}&season=${year}`
   if (current) {
     url += "&current=true"
   }
 
-  const res = await fetch(url, requestOptions)
+  const res = await fetch(url, {
+    method: "GET",
+    headers: getFootballHeaders(token),
+    next: {
+      revalidate: CACHE_REVALIDATE.rounds,
+      tags: [cacheTags.rounds({ leagueId, year, current })],
+    },
+  })
 
   if (!res.ok) {
     // This will activate the closest `error.js` Error Boundary
@@ -229,15 +321,6 @@ export async function fetchFixtures({
     throw new Error("RAPID_API_KEY environment variable is not set")
   }
 
-  const myHeaders = new Headers()
-  myHeaders.append("x-rapidapi-key", token)
-  myHeaders.append("x-rapidapi-host", "v3.football.api-sports.io")
-
-  const requestOptions = {
-    method: "GET",
-    headers: myHeaders,
-  }
-
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
   let url = `${FOOTBALL_API_SPORTS}/fixtures?league=${leagueId}&season=${year}&timezone=${timezone}`
@@ -245,7 +328,16 @@ export async function fetchFixtures({
     url += `&round=${round}`
   }
 
-  const res = await fetch(url, requestOptions)
+  const res = await fetch(url, {
+    method: "GET",
+    headers: getFootballHeaders(token),
+    next: {
+      revalidate: round
+        ? CACHE_REVALIDATE.fixtures
+        : CACHE_REVALIDATE.fixturesAll,
+      tags: [cacheTags.fixtures({ leagueId, year, round })],
+    },
+  })
 
   if (!res.ok) {
     // This will activate the closest `error.js` Error Boundary
@@ -320,18 +412,16 @@ export async function fetchStandings({
     throw new Error("RAPID_API_KEY environment variable is not set")
   }
 
-  const myHeaders = new Headers()
-  myHeaders.append("x-rapidapi-key", token)
-  myHeaders.append("x-rapidapi-host", "v3.football.api-sports.io")
-
-  const requestOptions = {
-    method: "GET",
-    headers: myHeaders,
-  }
-
   const url = `${FOOTBALL_API_SPORTS}/standings?league=${leagueId}&season=${year}`
 
-  const res = await fetch(url, requestOptions)
+  const res = await fetch(url, {
+    method: "GET",
+    headers: getFootballHeaders(token),
+    next: {
+      revalidate: CACHE_REVALIDATE.standings,
+      tags: [cacheTags.standings({ leagueId, year })],
+    },
+  })
 
   if (!res.ok) {
     throw new Error("Failed to fetch data")

--- a/app/news/[uid]/page.tsx
+++ b/app/news/[uid]/page.tsx
@@ -1,5 +1,7 @@
 import { createClient } from "@/prismicio"
 
+export const revalidate = 3600
+
 async function NewsPost(props: any) {
   const params = await props.params;
   const client = createClient()

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -2,6 +2,8 @@ import { createClient } from "@/prismicio"
 import PageTitle from "../components/pageTitle"
 import NewsList from "../ui/news/newsList"
 
+export const revalidate = 3600
+
 async function News() {
   const client = createClient()
   const documents = await client.getAllByType("news", {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,9 @@
-import { Suspense } from "react"
 import { getTranslations } from "next-intl/server"
-import BoloesList from "@/app/ui/home/boloesList"
-import { currentUser } from "@clerk/nextjs/server"
 import PageTitle from "./components/pageTitle"
-import { BoloesListSkeleton } from "@/app/ui/skeletons"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import InviteRedirector from "@/app/components/InviteRedirector"
+import HomeHeroActions from "@/app/components/homeHeroActions"
 
 // ISR: revalidate cached page every 5 minutes
 export const revalidate = 300
@@ -14,29 +11,8 @@ export const revalidate = 300
 const sectionSpaceing = "mb-18"
 
 async function Home() {
-  const user = await currentUser()
   const t = await getTranslations("home")
-
-  if (user) {
-    return (
-      <main>
-        <InviteRedirector />
-        <PageTitle>
-          {t("greeting")}
-          <br />
-          <span className="font-bold">
-            {user.username
-              ? `${user.username}.`
-              : user.emailAddresses[0].emailAddress.split("@")[0]}
-          </span>
-        </PageTitle>
-
-        <Suspense fallback={<BoloesListSkeleton />}>
-          <BoloesList />
-        </Suspense>
-      </main>
-    )
-  }
+  const tCommon = await getTranslations("common")
 
   return (
     <main className="max-w-4xl mx-auto px-4">
@@ -53,14 +29,12 @@ async function Home() {
           {t("tagline3")}
         </p>
 
-        <div className="flex items-center justify-center gap-4 mb-4">
-          <Button asChild>
-            <Link href="/sign-up">{t("getStarted")}</Link>
-          </Button>
-          <Button asChild variant="secondary">
-            <Link href="/sign-in">{t("login")}</Link>
-          </Button>
-        </div>
+        <HomeHeroActions
+          getStartedLabel={t("getStarted")}
+          loginLabel={t("login")}
+          dashboardLabel={t("dashboard")}
+          createBolaoLabel={tCommon("createBolao")}
+        />
 
         <Link
           href="/about"

--- a/messages/en.json
+++ b/messages/en.json
@@ -13,6 +13,7 @@
     "tagline3": "Win bragging rights.",
     "getStarted": "GET STARTED",
     "login": "LOGIN",
+    "dashboard": "MY BOLÕES",
     "learnMore": "Learn more about Bolão.io",
     "whatIsBolao": "What is a bolão?",
     "whatIsBolaoDesc": "In Brazil, a bolão is a betting pool between friends around soccer championships. It's very popular during the World Cup and major tournaments. This app makes it easy to create and manage your own - no money involved, just friendly competition!",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -13,6 +13,7 @@
     "tagline3": "Ganhe o direito de se gabar.",
     "getStarted": "COMEÇAR",
     "login": "ENTRAR",
+    "dashboard": "MEUS BOLÕES",
     "learnMore": "Saiba mais sobre o Bolão.io",
     "whatIsBolao": "O que é um bolão?",
     "whatIsBolaoDesc": "No Brasil, um bolão é uma aposta entre amigos sobre campeonatos de futebol. É muito popular durante a Copa do Mundo e grandes torneios. Este app facilita criar e gerenciar o seu próprio - sem dinheiro envolvido, apenas competição amigável!",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,10 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 
-const isProtectedRoute = createRouteMatcher(["/bolao(.*)", "/admin(.*)"])
+const isProtectedRoute = createRouteMatcher([
+  "/dashboard(.*)",
+  "/bolao(.*)",
+  "/admin(.*)",
+])
 
 export default clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) await auth.protect()

--- a/tests/e2e/bolao-full-flow.spec.ts
+++ b/tests/e2e/bolao-full-flow.spec.ts
@@ -56,16 +56,8 @@ test("Full bolão flow: create, navigate, and delete a bolão", async ({
   // Verify login was successful by checking for the dashboard greeting
   await expect(page.getByText(`${expectedUsername}.`)).toBeVisible()
 
-  // Verify the "Create bolão" link is visible on the home page
-  await expect(
-    page.getByRole("main").getByRole("link", { name: "Create bolão" })
-  ).toBeVisible()
-
-  // Navigate to the create bolão page
-  await page
-    .getByRole("main")
-    .getByRole("link", { name: "Create bolão" })
-    .click()
+  // Navigate directly to the protected create page once the session is confirmed.
+  await page.goto("http://localhost:3000/bolao/create")
 
   // Fill in the bolão creation form
   await page.getByRole("textbox", { name: "Name:" }).click()

--- a/tests/e2e/bolao-full-flow.spec.ts
+++ b/tests/e2e/bolao-full-flow.spec.ts
@@ -49,7 +49,11 @@ test("Full bolão flow: create, navigate, and delete a bolão", async ({
   await page.getByRole("textbox", { name: "Password" }).fill(testPassword)
   await page.getByRole("button", { name: "Continue" }).click()
 
-  // Verify login was successful by checking for the welcome message
+  // Signed-in users now land on the public home page first, then move to the dashboard.
+  await expect(page.getByRole("link", { name: "MY BOLÕES" })).toBeVisible()
+  await page.getByRole("link", { name: "MY BOLÕES" }).click()
+
+  // Verify login was successful by checking for the dashboard greeting
   await expect(page.getByText(`${expectedUsername}.`)).toBeVisible()
 
   // Verify the "Create bolão" link is visible on the home page
@@ -79,8 +83,8 @@ test("Full bolão flow: create, navigate, and delete a bolão", async ({
     openToastWithText(page, "The bolão was successfully created.")
   ).toBeVisible({ timeout: 15_000 })
 
-  // Navigate back to home page using the logo link in the header
-  await page.getByTestId("logo-link-header").click()
+  // Navigate back to the dashboard page where the user's bolões are listed
+  await page.goto("http://localhost:3000/dashboard")
 
   // Verify the newly created bolão appears on the home page
   await expect(
@@ -129,8 +133,8 @@ test("Full bolão flow: create, navigate, and delete a bolão", async ({
     page.getByRole("heading", { name: "Players lead" })
   ).toBeVisible()
 
-  // Navigate back to home page using the logo link
-  await page.getByTestId("logo-link-header").click()
+  // Navigate back to the dashboard page for cleanup
+  await page.goto("http://localhost:3000/dashboard")
 
   // Clean up: Delete the test bolão
   // Open the dropdown menu for this bolão's card only


### PR DESCRIPTION
## Summary
- cache shared API-Sports, bolao membership, and Clerk roster reads with Next cache tags and revalidation so repeated requests reuse warm data
- protect cache invalidation and preview flows with a secret-backed `/api/revalidate` endpoint plus explicit `no-store` headers on preview and revalidation routes
- keep `/` focused on public landing content and move the signed-in bolao list into `/dashboard` so public traffic has a cleaner path to cached HTML
- update Playwright full bolão flow e2e for the dashboard split so pre-push checks match the new navigation

## Test plan
- [x] `yarn test`
- [x] `yarn test:e2e`
- [x] `yarn build`
- [ ] Set `REVALIDATE_SECRET` on the Vercel staging project (required for `POST /api/revalidate` after this change)
- [ ] Verify the branch in Vercel staging and compare `x-vercel-cache` / TTFB on `/`, `/dashboard`, and a bolao page