### PR TITLE
fix: return all bolão members from Clerk user list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
 
 # local env files
 .env*.local

--- a/app/lib/__tests__/controllerLead.test.ts
+++ b/app/lib/__tests__/controllerLead.test.ts
@@ -186,6 +186,7 @@ describe("controllerLead", () => {
 
       expect(mockGetUserList).toHaveBeenCalledWith({
         userId: ["user-1", "user-2"],
+        limit: 2,
       })
     })
 

--- a/app/lib/__tests__/controllerResults.test.ts
+++ b/app/lib/__tests__/controllerResults.test.ts
@@ -465,6 +465,7 @@ describe("controllerResults", () => {
 
       expect(mockGetUserList).toHaveBeenCalledWith({
         userId: ["user-1", "user-2"],
+        limit: 2,
       })
     })
 

--- a/app/lib/__tests__/players.test.ts
+++ b/app/lib/__tests__/players.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  fetchClerkUsersByIds,
+  getPlayersFromUsersBolao,
+} from "../players"
+import type { UserBolao } from "@/app/lib/definitions"
+
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: vi.fn(),
+}))
+
+describe("players", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("fetchClerkUsersByIds", () => {
+    it("returns empty array without calling Clerk when no user ids", async () => {
+      const { clerkClient } = await import("@clerk/nextjs/server")
+      const mockGetUserList = vi.fn()
+      vi.mocked(clerkClient).mockResolvedValue({
+        users: { getUserList: mockGetUserList },
+      } as any)
+
+      const result = await fetchClerkUsersByIds([])
+
+      expect(result).toEqual([])
+      expect(mockGetUserList).not.toHaveBeenCalled()
+    })
+
+    it("passes limit matching batch size so more than 10 members are returned", async () => {
+      const { clerkClient } = await import("@clerk/nextjs/server")
+      const userIds = Array.from({ length: 11 }, (_, i) => `user-${i + 1}`)
+      const mockGetUserList = vi.fn().mockResolvedValue({
+        data: userIds.map((id) => ({
+          id,
+          username: id,
+          emailAddresses: [{ emailAddress: `${id}@example.com` }],
+        })),
+      })
+      vi.mocked(clerkClient).mockResolvedValue({
+        users: { getUserList: mockGetUserList },
+      } as any)
+
+      const result = await fetchClerkUsersByIds(userIds)
+
+      expect(mockGetUserList).toHaveBeenCalledTimes(1)
+      expect(mockGetUserList).toHaveBeenCalledWith({
+        userId: userIds,
+        limit: 11,
+      })
+      expect(result).toHaveLength(11)
+    })
+
+    it("batches requests when more than 100 user ids are provided", async () => {
+      const { clerkClient } = await import("@clerk/nextjs/server")
+      const userIds = Array.from({ length: 101 }, (_, i) => `user-${i + 1}`)
+      const mockGetUserList = vi
+        .fn()
+        .mockImplementation(({ userId }: { userId: string[] }) =>
+          Promise.resolve({
+            data: userId.map((id) => ({
+              id,
+              username: id,
+              emailAddresses: [{ emailAddress: `${id}@example.com` }],
+            })),
+          })
+        )
+      vi.mocked(clerkClient).mockResolvedValue({
+        users: { getUserList: mockGetUserList },
+      } as any)
+
+      const result = await fetchClerkUsersByIds(userIds)
+
+      expect(mockGetUserList).toHaveBeenCalledTimes(2)
+      expect(mockGetUserList).toHaveBeenNthCalledWith(1, {
+        userId: userIds.slice(0, 100),
+        limit: 100,
+      })
+      expect(mockGetUserList).toHaveBeenNthCalledWith(2, {
+        userId: userIds.slice(100),
+        limit: 1,
+      })
+      expect(result).toHaveLength(101)
+    })
+  })
+
+  describe("getPlayersFromUsersBolao", () => {
+    it("maps all bolao members to player data", async () => {
+      const { clerkClient } = await import("@clerk/nextjs/server")
+      const usersBolao: UserBolao[] = Array.from({ length: 11 }, (_, i) => ({
+        id: `ub-${i + 1}`,
+        bolao_id: "bolao-1",
+        user_id: `user-${i + 1}`,
+      }))
+      const mockGetUserList = vi.fn().mockResolvedValue({
+        data: usersBolao.map((ub) => ({
+          id: ub.user_id,
+          username: ub.user_id,
+          emailAddresses: [{ emailAddress: `${ub.user_id}@example.com` }],
+        })),
+      })
+      vi.mocked(clerkClient).mockResolvedValue({
+        users: { getUserList: mockGetUserList },
+      } as any)
+
+      const players = await getPlayersFromUsersBolao(usersBolao)
+
+      expect(players).toHaveLength(11)
+      expect(players[0]).toEqual({
+        id: "user-1",
+        username: "user-1",
+        email: "user-1@example.com",
+        userBolaoId: "ub-1",
+      })
+      expect(players[10]).toEqual({
+        id: "user-11",
+        username: "user-11",
+        email: "user-11@example.com",
+        userBolaoId: "ub-11",
+      })
+    })
+  })
+})

--- a/app/lib/controllerBet.ts
+++ b/app/lib/controllerBet.ts
@@ -12,26 +12,7 @@ import {
   pickCurrentRoundFromApiCurrent,
 } from "@/app/lib/utils"
 import { Bet, PlayersData, UserBolao } from "@/app/lib/definitions"
-import { clerkClient } from "@clerk/nextjs/server"
-
-async function getPlayers(usersBolao: UserBolao[]) {
-  const userIds: string[] = usersBolao.map((el: UserBolao) => el.user_id)
-  const client = await clerkClient()
-  const users = await client.users.getUserList({ userId: userIds })
-
-  return users.data.map((el) => {
-    const userBolaoObj = usersBolao.find(
-      (ub: UserBolao) => ub.user_id === el.id
-    )
-
-    return {
-      id: el.id,
-      username: el.username,
-      email: el.emailAddresses[0]?.emailAddress || "",
-      userBolaoId: userBolaoObj?.id || "",
-    }
-  })
-}
+import { getPlayersFromUsersBolao } from "./players"
 
 export async function getData({
   bolaoId,
@@ -59,7 +40,7 @@ export async function getData({
 
   if (isAdmin) {
     const usersBolao: UserBolao[] = await fetchUsersBolao(bolaoId)
-    players = await getPlayers(usersBolao)
+    players = await getPlayersFromUsersBolao(usersBolao)
 
     selectedUserBolao =
       usersBolao.find((el) => el.id === selectedUserBolaoId) || userBolao

--- a/app/lib/controllerLead.ts
+++ b/app/lib/controllerLead.ts
@@ -4,8 +4,8 @@ import {
   fetchFixtures,
   fetchUsersBets,
 } from "@/app/lib/data"
-import { FixtureData, UserBolao, PlayersData, Bet } from "./definitions"
-import { clerkClient } from "@clerk/nextjs/server"
+import { FixtureData, UserBolao, Bet } from "./definitions"
+import { getPlayersFromUsersBolao } from "./players"
 
 export async function getData({ bolaoId }: { bolaoId: string }) {
   const [bolao, usersBolao] = await Promise.all([
@@ -16,27 +16,7 @@ export async function getData({ bolaoId }: { bolaoId: string }) {
   const year: number = bolao.year
   const leagueId: string = bolao.competition_id
 
-  // Fetch players infos
-  const userIds: string[] = usersBolao.map((el: UserBolao) => el.user_id)
-  const client = await clerkClient()
-  const users = await client.users.getUserList({ userId: userIds })
-
-  const players: PlayersData[] = []
-  users.data.map((el) => {
-    // TODO: fix the "any" type
-    const userBolaoObj: any = usersBolao.find(
-      (ub: UserBolao) => ub.user_id === el.id
-    )
-
-    const obj = {
-      id: el.id,
-      username: el.username,
-      email: el.emailAddresses[0].emailAddress,
-      userBolaoId: userBolaoObj.id,
-    }
-
-    players.push(obj)
-  })
+  const players = await getPlayersFromUsersBolao(usersBolao)
 
   // Fetch all fixtures
   const fixtures: FixtureData[] = await fetchFixtures({ leagueId, year })

--- a/app/lib/controllerResults.ts
+++ b/app/lib/controllerResults.ts
@@ -10,8 +10,8 @@ import {
   cleanRounds,
   pickCurrentRoundFromApiCurrent,
 } from "@/app/lib/utils"
-import { Bet, UserBolao, PlayersData } from "@/app/lib/definitions"
-import { clerkClient } from "@clerk/nextjs/server"
+import { Bet, UserBolao } from "@/app/lib/definitions"
+import { getPlayersFromUsersBolao } from "./players"
 
 export async function getData({
   bolaoId,
@@ -28,27 +28,7 @@ export async function getData({
   const year: number = bolao.year
   const leagueId: string = bolao.competition_id
 
-  // Fetch players infos
-  const userIds: string[] = usersBolao.map((el: UserBolao) => el.user_id)
-  const client = await clerkClient()
-  const users = await client.users.getUserList({ userId: userIds })
-
-  const players: PlayersData[] = []
-  users.data.map((el) => {
-    // TODO: fix the "any" type
-    const userBolaoObj: any = usersBolao.find(
-      (ub: UserBolao) => ub.user_id === el.id
-    )
-
-    const obj = {
-      id: el.id,
-      username: el.username,
-      email: el.emailAddresses[0].emailAddress,
-      userBolaoId: userBolaoObj.id,
-    }
-
-    players.push(obj)
-  })
+  const players = await getPlayersFromUsersBolao(usersBolao)
 
   // Fetch bets
   const userBoloesIds: string[] = usersBolao.map((el: UserBolao) => el.id)

--- a/app/lib/players.ts
+++ b/app/lib/players.ts
@@ -1,0 +1,42 @@
+import { clerkClient } from "@clerk/nextjs/server"
+import { PlayersData, UserBolao } from "./definitions"
+
+const CLERK_USER_ID_BATCH_SIZE = 100
+
+export async function fetchClerkUsersByIds(userIds: string[]) {
+  if (userIds.length === 0) {
+    return []
+  }
+
+  const client = await clerkClient()
+  const users = []
+
+  for (let i = 0; i < userIds.length; i += CLERK_USER_ID_BATCH_SIZE) {
+    const batch = userIds.slice(i, i + CLERK_USER_ID_BATCH_SIZE)
+    const result = await client.users.getUserList({
+      userId: batch,
+      limit: batch.length,
+    })
+    users.push(...result.data)
+  }
+
+  return users
+}
+
+export async function getPlayersFromUsersBolao(
+  usersBolao: UserBolao[]
+): Promise<PlayersData[]> {
+  const userIds = usersBolao.map((el) => el.user_id)
+  const clerkUsers = await fetchClerkUsersByIds(userIds)
+
+  return clerkUsers.map((el) => {
+    const userBolaoObj = usersBolao.find((ub) => ub.user_id === el.id)
+
+    return {
+      id: el.id,
+      username: el.username,
+      email: el.emailAddresses[0]?.emailAddress || "",
+      userBolaoId: userBolaoObj?.id || "",
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- Fix members disappearing from lead, results, and the admin "Betting as" dropdown when a bolão exceeds 10 players
- Add shared Clerk user fetching in `app/lib/players.ts` with explicit `limit` and 100-ID batching
- Add unit tests for 11+ member groups and ignore `*.log` files in git

## Root cause

`client.users.getUserList({ userId: userIds })` was called without a `limit`. Clerk defaults to returning only 10 users, so older members (often the creator) were silently dropped once the 11th player joined.

## Test plan

- [x] Open a bolão with 11+ members on Lead, Results, and Bet tabs
- [x] Confirm all members appear, including the creator
- [x] Confirm the admin "Betting as" dropdown lists every member
- [x] Run `yarn test app/lib/__tests__/players.test.ts app/lib/__tests__/controllerLead.test.ts app/lib/__tests__/controllerBet.test.ts app/lib/__tests__/controllerResults.test.ts`


Made with [Cursor](https://cursor.com)