### PR TITLE
fix(ui): opaque background on results table sticky corner

### DIFF
--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -98,7 +98,9 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
           <CardContent>
           <StickyTable borderWidth={0}>
             <Row>
-              <Cell style={cellStyles}>&nbsp;</Cell>
+              <Cell style={{ ...cellStyles, backgroundColor: "white" }}>
+                &nbsp;
+              </Cell>
               {players.map((player: PlayersData) => {
                 return (
                   <Cell style={cellStyles} key={player.id}>


### PR DESCRIPTION
## Summary

- Set a white background on the sticky top-left corner cell in the results table so player column headers do not bleed through when scrolling horizontally

## Test plan

- [ ] Open a bolão results page with 10+ players on mobile
- [ ] Scroll horizontally and confirm the corner cell stays opaque over scrolling player names


Made with [Cursor](https://cursor.com)