### PR TITLE
feat(bet): championship winner pick (+500 bonus)

### DIFF
--- a/app/__tests__/bolao/[id]/bet/page.test.tsx
+++ b/app/__tests__/bolao/[id]/bet/page.test.tsx
@@ -2,149 +2,180 @@ import { render, screen } from "@testing-library/react"
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import BetPage from "@/app/bolao/[id]/bet/page"
 import { getData } from "@/app/lib/controllerBet"
-import { auth, clerkClient } from "@clerk/nextjs/server"
+import { auth } from "@clerk/nextjs/server"
 
-// Mock dependencies
 vi.mock("@/app/lib/controllerBet")
 vi.mock("@clerk/nextjs/server")
 vi.mock("@/app/ui/bolao/bolaoPageTitle", () => ({
-    default: (props: any) => <div data-testid="bolao-page-title" data-props={JSON.stringify(props)} />
+  default: (props: any) => (
+    <div data-testid="bolao-page-title" data-props={JSON.stringify(props)} />
+  ),
 }))
 vi.mock("@/app/ui/bolao/bolaoLinks", () => ({
-    default: (props: any) => <div data-testid="bolao-links" data-props={JSON.stringify(props)} />
+  default: (props: any) => (
+    <div data-testid="bolao-links" data-props={JSON.stringify(props)} />
+  ),
 }))
 vi.mock("@/app/ui/bolao/bet/pagination", () => ({
-    default: (props: any) => <div data-testid="pagination" data-props={JSON.stringify(props)} />
+  default: (props: any) => (
+    <div data-testid="pagination" data-props={JSON.stringify(props)} />
+  ),
 }))
 vi.mock("@/app/ui/bolao/bet/playerSelector", () => ({
-    default: (props: any) => <div data-testid="player-selector" data-props={JSON.stringify(props)} />
+  default: (props: any) => (
+    <div data-testid="player-selector" data-props={JSON.stringify(props)} />
+  ),
+}))
+vi.mock("@/app/ui/bolao/bet/championPickSelector", () => ({
+  default: (props: any) => (
+    <div
+      data-testid="champion-pick-selector"
+      data-props={JSON.stringify(props)}
+    />
+  ),
 }))
 vi.mock("@/app/ui/bolao/bet/tableMatchDayBets", () => ({
-    default: (props: any) => <div data-testid="table-match-day-bets" data-props={JSON.stringify(props)} />
+  default: (props: any) => (
+    <div
+      data-testid="table-match-day-bets"
+      data-props={JSON.stringify(props)}
+    />
+  ),
 }))
 
 describe("BetPage", () => {
-    const mockParams = Promise.resolve({ id: "bolao-123" })
-    const mockSearchParams = Promise.resolve({ roundIndex: "1" })
+  const mockParams = Promise.resolve({ id: "bolao-123" })
+  const mockSearchParams = Promise.resolve({ roundIndex: "1" })
 
-    beforeEach(() => {
-        vi.clearAllMocks()
-        ;(auth as any).mockResolvedValue({ userId: "user-123" })
-        ;(clerkClient as any).mockResolvedValue({
-            users: {
-                getUser: vi.fn().mockResolvedValue({
-                    privateMetadata: { role: "user" },
-                }),
-            },
-        })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(auth as any).mockResolvedValue({ userId: "user-123" })
+  })
+
+  it("should render error if userId is missing", async () => {
+    ;(auth as any).mockResolvedValue({ userId: null })
+
+    const result = await BetPage({
+      params: mockParams,
+      searchParams: mockSearchParams,
+    })
+    render(result)
+
+    expect(
+      screen.getByText("Error while loading the bet page. Missing userid.")
+    ).toBeDefined()
+  })
+
+  it("should render error if data loading throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    ;(getData as any).mockRejectedValue(new Error("db timeout"))
+
+    const result = await BetPage({
+      params: mockParams,
+      searchParams: mockSearchParams,
+    })
+    render(result)
+
+    expect(
+      screen.getByText(
+        "Could not load the bet page. Check your connection and try again."
+      )
+    ).toBeDefined()
+    consoleError.mockRestore()
+  })
+
+  it("should render error if data is missing fixtures", async () => {
+    ;(getData as any).mockResolvedValue({
+      fixtures: [],
+      allRounds: [],
+      currentRound: "Round 1",
     })
 
-    it("should render error if userId is missing", async () => {
-        (auth as any).mockResolvedValue({ userId: null })
-
-        const result = await BetPage({ params: mockParams, searchParams: mockSearchParams })
-        render(result)
-
-        expect(screen.getByText("Error while loading the bet page. Missing userid.")).toBeDefined()
+    const result = await BetPage({
+      params: mockParams,
+      searchParams: mockSearchParams,
     })
+    render(result)
 
-    it("should render error if data is missing", async () => {
-        (auth as any).mockResolvedValue({ userId: "user-123" });
-        (getData as any).mockResolvedValue(null);
+    expect(
+      screen.getByText("Error while loading the bet page. No data.")
+    ).toBeDefined()
+  })
 
-        const result = await BetPage({ params: mockParams, searchParams: mockSearchParams })
-        render(result)
+  it("should render page content when data is present", async () => {
+    const mockData = {
+      bolao: { id: "bolao-123", year: 2023, competition_id: "comp-1" },
+      userBolao: { id: "user-bolao-123" },
+      currentUserBolao: { id: "user-bolao-123" },
+      isAdmin: false,
+      currentRound: "Round 1",
+      allRounds: ["Round 1", "Round 2"],
+      fixtures: [{ league: { logo: "logo.png", name: "League Name" } }],
+      isLastRound: false,
+      isFirstRound: true,
+      bets: [],
+      players: [],
+      championPickTeams: [],
+      userChampionPick: null,
+      isChampionPickLocked: false,
+      championPickLockDate: null,
+    }
+    ;(getData as any).mockResolvedValue(mockData)
 
-        expect(screen.getByText("Error while loading the bet page. No data.")).toBeDefined()
+    const result = await BetPage({
+      params: mockParams,
+      searchParams: mockSearchParams,
     })
+    render(result)
 
-    it("should render page content when data is present", async () => {
-        const mockData = {
-            bolao: { id: "bolao-123", year: 2023, competition_id: "comp-1" },
-            userBolao: { id: "user-bolao-123" },
-            currentUserBolao: { id: "user-bolao-123" },
-            currentRound: "Round 1",
-            allRounds: ["Round 1", "Round 2"],
-            fixtures: [{ league: { logo: "logo.png", name: "League Name" } }],
-            isLastRound: false,
-            isFirstRound: true,
-            bets: [],
-            players: []
-        };
-        (getData as any).mockResolvedValue(mockData);
+    expect(screen.getByTestId("bolao-page-title")).toBeDefined()
+    expect(screen.getByTestId("bolao-links")).toBeDefined()
+    expect(screen.getByTestId("pagination")).toBeDefined()
+    expect(screen.getByTestId("table-match-day-bets")).toBeDefined()
+  })
 
-        const result = await BetPage({ params: mockParams, searchParams: mockSearchParams })
-        render(result)
+  it("should render player selector for admins", async () => {
+    const mockData = {
+      bolao: { id: "bolao-123", year: 2023, competition_id: "comp-1" },
+      userBolao: { id: "selected-user-bolao" },
+      currentUserBolao: { id: "user-bolao-123" },
+      isAdmin: true,
+      currentRound: "Round 1",
+      allRounds: ["Round 1", "Round 2"],
+      fixtures: [{ league: { logo: "logo.png", name: "League Name" } }],
+      isLastRound: false,
+      isFirstRound: true,
+      bets: [],
+      players: [
+        {
+          id: "user-123",
+          username: "Kevin",
+          email: "kevin@example.com",
+          userBolaoId: "user-bolao-123",
+        },
+      ],
+      championPickTeams: [],
+      userChampionPick: null,
+      isChampionPickLocked: false,
+      championPickLockDate: null,
+    }
+    ;(getData as any).mockResolvedValue(mockData)
 
-        expect(screen.getByTestId("bolao-page-title")).toBeDefined()
-        expect(screen.getByTestId("bolao-links")).toBeDefined()
-        expect(screen.getByTestId("pagination")).toBeDefined()
-        expect(screen.getByTestId("table-match-day-bets")).toBeDefined()
-
-        // Verify props passed to components (optional but good)
-        const title = screen.getByTestId("bolao-page-title")
-        const titleProps = JSON.parse(title.getAttribute("data-props") || "{}")
-        expect(titleProps.bolao).toEqual(mockData.bolao)
-        expect(titleProps.leagueLogo).toBe("logo.png")
-        expect(titleProps.leagueName).toBe("League Name")
+    const result = await BetPage({
+      params: mockParams,
+      searchParams: Promise.resolve({
+        roundIndex: "1",
+        userBolaoId: "selected-user-bolao",
+      }),
     })
+    render(result)
 
-    it("should pass admin selection to getData and render player selector", async () => {
-        ;(clerkClient as any).mockResolvedValue({
-            users: {
-                getUser: vi.fn().mockResolvedValue({
-                    privateMetadata: { role: "admin" },
-                }),
-            },
-        })
-
-        const mockData = {
-            bolao: { id: "bolao-123", year: 2023, competition_id: "comp-1" },
-            userBolao: { id: "selected-user-bolao" },
-            currentUserBolao: { id: "user-bolao-123" },
-            currentRound: "Round 1",
-            allRounds: ["Round 1", "Round 2"],
-            fixtures: [{ league: { logo: "logo.png", name: "League Name" } }],
-            isLastRound: false,
-            isFirstRound: true,
-            bets: [],
-            players: [
-                {
-                    id: "user-123",
-                    username: "Kevin",
-                    email: "kevin@example.com",
-                    userBolaoId: "user-bolao-123",
-                },
-                {
-                    id: "user-456",
-                    username: "Other",
-                    email: "other@example.com",
-                    userBolaoId: "selected-user-bolao",
-                },
-            ],
-        };
-        (getData as any).mockResolvedValue(mockData);
-
-        const result = await BetPage({
-            params: mockParams,
-            searchParams: Promise.resolve({
-                roundIndex: "1",
-                userBolaoId: "selected-user-bolao",
-            }),
-        })
-        render(result)
-
-        expect(getData).toHaveBeenCalledWith({
-            bolaoId: "bolao-123",
-            roundParam: "1",
-            userId: "user-123",
-            isAdmin: true,
-            selectedUserBolaoId: "selected-user-bolao",
-        })
-
-        const selector = screen.getByTestId("player-selector")
-        const selectorProps = JSON.parse(selector.getAttribute("data-props") || "{}")
-        expect(selectorProps.selectedUserBolaoId).toBe("selected-user-bolao")
-        expect(selectorProps.players).toEqual(mockData.players)
+    expect(getData).toHaveBeenCalledWith({
+      bolaoId: "bolao-123",
+      roundParam: "1",
+      userId: "user-123",
+      selectedUserBolaoId: "selected-user-bolao",
     })
+    expect(screen.getByTestId("player-selector")).toBeDefined()
+  })
 })

--- a/app/__tests__/bolao/[id]/lead/page.test.tsx
+++ b/app/__tests__/bolao/[id]/lead/page.test.tsx
@@ -6,7 +6,14 @@ import { calcLead } from "@/app/lib/calcLeadFactory"
 
 // Mock dependencies
 vi.mock("@/app/lib/controllerLead")
-vi.mock("@/app/lib/calcLeadFactory")
+vi.mock("@/app/lib/calcLeadFactory", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/app/lib/calcLeadFactory")>()
+  return {
+    ...actual,
+    calcLead: vi.fn(),
+  }
+})
 vi.mock("@/app/ui/bolao/bolaoPageTitle", () => ({
     default: (props: any) => <div data-testid="bolao-page-title" data-props={JSON.stringify(props)} />
 }))
@@ -23,7 +30,10 @@ describe("LeadPage", () => {
         bolao: { id: "bolao-123", name: "Test Bolao" },
         players: [],
         fixtures: [{ league: { logo: "logo.png", name: "League Name" } }],
-        bets: []
+        bets: [],
+        championPicks: [],
+        isChampionPickLocked: false,
+        leagueWinnerTeamId: null,
     }
     const mockLeadData = [
         { id: "p1", name: "Player 1", total: 10 },
@@ -50,7 +60,9 @@ describe("LeadPage", () => {
         expect(calcLead).toHaveBeenCalledWith({
             players: mockData.players,
             fixtures: mockData.fixtures,
-            bets: mockData.bets
+            bets: mockData.bets,
+            championPicks: mockData.championPicks,
+            leagueWinnerTeamId: mockData.leagueWinnerTeamId,
         })
 
         // Verify sorting
@@ -59,5 +71,28 @@ describe("LeadPage", () => {
         expect(tableProps.data).toHaveLength(2)
         expect(tableProps.data[0].total).toBe(20) // Player 2 (20) should be first
         expect(tableProps.data[1].total).toBe(10) // Player 1 (10) should be second
+    })
+
+    it("strips champion picks from lead data before lock", async () => {
+        (getData as any).mockResolvedValue({
+            ...mockData,
+            isChampionPickLocked: false,
+        });
+        (calcLead as any).mockReturnValue([
+            {
+                name: "Player 1",
+                total: 10,
+                championPick: { id: 10, name: "Brazil", logo: "b.png" },
+            },
+        ])
+
+        const result = await LeadPage({ params: mockParams })
+        render(result)
+
+        const tableProps = JSON.parse(
+            screen.getByTestId("table-lead").getAttribute("data-props") || "{}"
+        )
+
+        expect(tableProps.data[0].championPick).toBeNull()
     })
 })

--- a/app/__tests__/layout.test.tsx
+++ b/app/__tests__/layout.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { renderToString } from "react-dom/server"
 import RootLayout, { metadata } from "../layout"
 
 // Mock ClerkProvider
@@ -25,6 +25,10 @@ vi.mock("@/components/ui/toaster", () => ({
 // Mock Analytics component
 vi.mock("@vercel/analytics/react", () => ({
   Analytics: () => <div data-testid="analytics">Analytics</div>,
+}))
+
+vi.mock("@vercel/speed-insights/next", () => ({
+  SpeedInsights: () => null,
 }))
 
 // Mock Next.js Script component
@@ -180,11 +184,12 @@ describe("RootLayout", () => {
       const Layout = await RootLayout({
         children: <div data-testid="child-content">Child Content</div>,
       })
-      const { container } = render(Layout)
-      // Verify structure
-      const mainContainer = container.querySelector(".container")
-      expect(mainContainer).toBeDefined()
-      expect(mainContainer?.className).toContain("mx-auto px-4")
+      const html = renderToString(Layout)
+
+      expect(html).toContain("Child Content")
+      expect(html).toContain("mx-auto px-4")
+      expect(html).toContain('data-testid="header"')
+      expect(html).toContain('data-testid="footer"')
     })
   })
 })

--- a/app/bolao/[id]/bet/page.tsx
+++ b/app/bolao/[id]/bet/page.tsx
@@ -1,11 +1,12 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, getLocale } from "next-intl/server"
 import { getData } from "@/app/lib/controllerBet"
-import { auth, clerkClient } from "@clerk/nextjs/server"
+import { auth } from "@clerk/nextjs/server"
 import BolaoPageTitle from "@/app/ui/bolao/bolaoPageTitle"
 import BolaoLinks from "@/app/ui/bolao/bolaoLinks"
 import Pagination from "@/app/ui/bolao/bet/pagination"
 import TableMatchDayBets from "@/app/ui/bolao/bet/tableMatchDayBets"
 import PlayerSelector from "@/app/ui/bolao/bet/playerSelector"
+import ChampionPickSelector from "@/app/ui/bolao/bet/championPickSelector"
 
 async function BetPage(props: {
   params: Promise<{ id: string }>
@@ -20,25 +21,26 @@ async function BetPage(props: {
   const roundIndex: string = searchParams?.roundIndex || ""
   const selectedUserBolaoId: string = searchParams?.userBolaoId || ""
   const t = await getTranslations("betPage")
+  const locale = await getLocale()
 
   if (!userId) {
     return <p>{t("errorMissingUser")}</p>
   }
 
-  const client = await clerkClient()
-  const userData = await client.users.getUser(userId)
-  const role = userData.privateMetadata?.role || "guest"
-  const isAdmin = role === "admin"
+  let data
+  try {
+    data = await getData({
+      bolaoId: params.id,
+      roundParam: roundIndex,
+      userId,
+      selectedUserBolaoId,
+    })
+  } catch (error) {
+    console.error("Bet page load failed:", error)
+    return <p>{t("errorLoadFailed")}</p>
+  }
 
-  const data = await getData({
-    bolaoId: params.id,
-    roundParam: roundIndex,
-    userId,
-    isAdmin,
-    selectedUserBolaoId,
-  })
-
-  if (!data) {
+  if (!data || data.fixtures.length === 0) {
     return <p>{t("errorNoData")}</p>
   }
 
@@ -64,10 +66,23 @@ async function BetPage(props: {
         currentRoundName={data.currentRound}
       />
 
-      {isAdmin && data.players.length > 0 && (
+      {data.isAdmin && data.players.length > 0 && (
         <PlayerSelector
           players={data.players}
           selectedUserBolaoId={data.userBolao.id}
+        />
+      )}
+
+      {data.championPickTeams.length > 0 && (
+        <ChampionPickSelector
+          bolaoId={params.id}
+          userBolaoId={data.currentUserBolao.id}
+          teams={data.championPickTeams}
+          userChampionPick={data.userChampionPick}
+          isLocked={data.isChampionPickLocked}
+          lockDate={data.championPickLockDate}
+          leagueWinnerTeamId={null}
+          locale={locale}
         />
       )}
 
@@ -75,7 +90,7 @@ async function BetPage(props: {
         bets={data.bets}
         fixtures={data.fixtures}
         userBolaoId={data.userBolao.id}
-        isAdmin={isAdmin}
+        isAdmin={data.isAdmin}
       />
     </main>
   )

--- a/app/bolao/[id]/lead/page.tsx
+++ b/app/bolao/[id]/lead/page.tsx
@@ -1,20 +1,26 @@
 import TableLead from "@/app/ui/bolao/lead/tableLead"
-import { calcLead } from "@/app/lib/calcLeadFactory"
+import { calcLead, prepareLeadForDisplay } from "@/app/lib/calcLeadFactory"
 import BolaoPageTitle from "@/app/ui/bolao/bolaoPageTitle"
 import BolaoLinks from "@/app/ui/bolao/bolaoLinks"
 import { getData } from "@/app/lib/controllerLead"
 import { LeadData } from "@/app/lib/definitions"
 
 async function LeadPage(props: { params: Promise<{ id: string }> }) {
-  const params = await props.params;
+  const params = await props.params
   const data = await getData({ bolaoId: params.id })
 
   const unsortedLead: LeadData[] = calcLead({
     players: data.players,
     fixtures: data.fixtures,
     bets: data.bets,
+    championPicks: data.championPicks,
+    leagueWinnerTeamId: data.leagueWinnerTeamId,
   })
   const sortedLead = [...unsortedLead].sort((a, b) => b.total - a.total)
+  const leadForDisplay = prepareLeadForDisplay(
+    sortedLead,
+    data.isChampionPickLocked
+  )
 
   return (
     <main>
@@ -26,7 +32,10 @@ async function LeadPage(props: { params: Promise<{ id: string }> }) {
 
       <BolaoLinks bolaoId={data.bolao.id} active={4} />
 
-      <TableLead data={sortedLead} />
+      <TableLead
+        data={leadForDisplay}
+        isChampionPickLocked={data.isChampionPickLocked}
+      />
     </main>
   )
 }

--- a/app/lib/__tests__/actions.test.ts
+++ b/app/lib/__tests__/actions.test.ts
@@ -23,12 +23,18 @@ vi.mock("@clerk/nextjs/server", () => ({
 // Mock data fetching
 vi.mock("../data", () => ({
   fetchLeague: vi.fn(),
+  fetchBolao: vi.fn(),
+  fetchFixtures: vi.fn(),
 }))
 
 // Mock utils
-vi.mock("../utils", () => ({
-  getCurrentSeasonObject: vi.fn(),
-}))
+vi.mock("../utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils")>()
+  return {
+    ...actual,
+    getCurrentSeasonObject: vi.fn(),
+  }
+})
 
 import {
   createUser,
@@ -41,12 +47,13 @@ import {
   deleteBolao,
   deleteUserBolao,
   deleteBet,
+  createOrUpdateChampionPick,
 } from "../actions"
 import { sql } from "@vercel/postgres"
 import { redirect } from "next/navigation"
 import { revalidatePath } from "next/cache"
 import { auth } from "@clerk/nextjs/server"
-import { fetchLeague } from "../data"
+import { fetchLeague, fetchBolao, fetchFixtures } from "../data"
 import { getCurrentSeasonObject } from "../utils"
 
 describe("actions", () => {
@@ -599,6 +606,93 @@ describe("actions", () => {
       const deleteResult = await deleteBet("bet-1")
 
       expect(deleteResult).toEqual([{ id: "bet-1" }])
+    })
+  })
+
+  describe("createOrUpdateChampionPick", () => {
+    const pickArgs = {
+      userBolaoId: "ub-1",
+      bolaoId: "bolao-1",
+      teamId: 10,
+      teamName: "Brazil",
+      teamLogo: "b.png",
+    }
+
+    beforeEach(() => {
+      vi.useRealTimers()
+      vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as any)
+      vi.mocked(fetchBolao).mockResolvedValue({
+        id: "bolao-1",
+        competition_id: "1",
+        year: 2026,
+      } as any)
+    })
+
+    it("rejects when user is not authenticated", async () => {
+      vi.mocked(auth).mockResolvedValue({ userId: null } as any)
+
+      const result = await createOrUpdateChampionPick(pickArgs)
+
+      expect(result).toEqual({ success: false, message: "Unauthorized." })
+    })
+
+    it("rejects when champion pick is locked", async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-12T12:00:00Z"))
+      vi.mocked(fetchFixtures).mockResolvedValue([
+        {
+          fixture: { date: new Date("2026-06-11T19:00:00Z") },
+        },
+      ] as any)
+
+      const result = await createOrUpdateChampionPick(pickArgs)
+
+      expect(result).toEqual({
+        success: false,
+        message: "Champion pick is locked.",
+      })
+      expect(sql).not.toHaveBeenCalled()
+    })
+
+    it("saves pick when unlocked", async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-10T12:00:00Z"))
+      vi.mocked(fetchFixtures).mockResolvedValue([
+        {
+          fixture: { date: new Date("2026-06-11T19:00:00Z") },
+        },
+      ] as any)
+      vi.mocked(sql).mockResolvedValue({
+        rows: [
+          {
+            id: "cp-1",
+            user_bolao_id: "ub-1",
+            team_id: 10,
+            team_name: "Brazil",
+            team_logo: "b.png",
+          },
+        ],
+      } as any)
+
+      const result = await createOrUpdateChampionPick(pickArgs)
+
+      expect(result.success).toBe(true)
+      expect(sql).toHaveBeenCalled()
+    })
+
+    it("returns forbidden when user does not own user_bolao", async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-10T12:00:00Z"))
+      vi.mocked(fetchFixtures).mockResolvedValue([
+        {
+          fixture: { date: new Date("2026-06-11T19:00:00Z") },
+        },
+      ] as any)
+      vi.mocked(sql).mockResolvedValue({ rows: [] } as any)
+
+      const result = await createOrUpdateChampionPick(pickArgs)
+
+      expect(result).toEqual({ success: false, message: "Forbidden." })
     })
   })
 })

--- a/app/lib/__tests__/authRole.test.ts
+++ b/app/lib/__tests__/authRole.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: vi.fn(),
+}))
+
+import { clerkClient } from "@clerk/nextjs/server"
+import { getUserRole } from "../authRole"
+
+describe("getUserRole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    console.error = vi.fn()
+  })
+
+  it("returns role from Clerk privateMetadata", async () => {
+    vi.mocked(clerkClient).mockResolvedValue({
+      users: {
+        getUser: vi.fn().mockResolvedValue({
+          privateMetadata: { role: "admin" },
+        }),
+      },
+    } as any)
+
+    await expect(getUserRole("user-1")).resolves.toBe("admin")
+  })
+
+  it("returns guest when Clerk has no role", async () => {
+    vi.mocked(clerkClient).mockResolvedValue({
+      users: {
+        getUser: vi.fn().mockResolvedValue({
+          privateMetadata: {},
+        }),
+      },
+    } as any)
+
+    await expect(getUserRole("user-1")).resolves.toBe("guest")
+  })
+
+  it("returns guest when Clerk fails", async () => {
+    vi.mocked(clerkClient).mockRejectedValue(new Error("clerk down"))
+
+    await expect(getUserRole("user-1")).resolves.toBe("guest")
+  })
+})

--- a/app/lib/__tests__/calcLeadFactory.test.ts
+++ b/app/lib/__tests__/calcLeadFactory.test.ts
@@ -1048,4 +1048,77 @@ describe("calcLead", () => {
       },
     ])
   })
+
+  it("adds champion pick bonus when pick matches league winner", () => {
+    const players: PlayersData[] = [
+      {
+        id: "user-1",
+        username: "alice",
+        email: "a@x.com",
+        userBolaoId: "ub-1",
+      },
+      {
+        id: "user-2",
+        username: "bob",
+        email: "b@x.com",
+        userBolaoId: "ub-2",
+      },
+    ]
+
+    const result = calcLead({
+      players,
+      fixtures: [],
+      bets: [],
+      championPicks: [
+        {
+          id: "cp-1",
+          user_bolao_id: "ub-1",
+          team_id: 10,
+          team_name: "Brazil",
+          team_logo: "b.png",
+          created_at: "",
+          updated_at: "",
+        },
+      ],
+      leagueWinnerTeamId: 10,
+    })
+
+    expect(result.find((entry) => entry.name === "alice")?.total).toBe(500)
+    expect(result.find((entry) => entry.name === "bob")?.total).toBe(0)
+    expect(result.find((entry) => entry.name === "alice")?.championPick?.name).toBe(
+      "Brazil"
+    )
+  })
+})
+
+describe("prepareLeadForDisplay", () => {
+  it("strips champion picks before lock", async () => {
+    const { prepareLeadForDisplay } = await import("../calcLeadFactory")
+
+    const lead = [
+      {
+        name: "alice",
+        total: 100,
+        championPick: { id: 10, name: "Brazil", logo: "b.png" },
+      },
+    ]
+
+    expect(prepareLeadForDisplay(lead, false)).toEqual([
+      { name: "alice", total: 100, championPick: null },
+    ])
+  })
+
+  it("keeps champion picks after lock", async () => {
+    const { prepareLeadForDisplay } = await import("../calcLeadFactory")
+
+    const lead = [
+      {
+        name: "alice",
+        total: 100,
+        championPick: { id: 10, name: "Brazil", logo: "b.png" },
+      },
+    ]
+
+    expect(prepareLeadForDisplay(lead, true)).toEqual(lead)
+  })
 })

--- a/app/lib/__tests__/championPick.test.ts
+++ b/app/lib/__tests__/championPick.test.ts
@@ -1,25 +1,56 @@
-import { describe, it, expect, vi, afterEach } from "vitest"
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
 import {
   isChampionPickLocked,
   getChampionPickLockDate,
   getTeamsFromFixtures,
 } from "../utils"
-import { getLeagueWinnerTeamId } from "../championPick"
-import type { FixtureData } from "../definitions"
+import {
+  isSeasonFinished,
+  getCupWinnerTeamId,
+  getLeagueWinnerFromStandings,
+  resolveChampionTeamId,
+} from "../championPick"
+import type { FixtureData, Standing } from "../definitions"
+
+vi.mock("../data", () => ({
+  fetchStandings: vi.fn(),
+}))
 
 function makeFixture(
   id: number,
   date: string,
-  home: { id: number; name: string },
-  away: { id: number; name: string }
+  home: { id: number; name: string; winner?: boolean | null },
+  away: { id: number; name: string; winner?: boolean | null },
+  statusShort: string = "NS"
 ): FixtureData {
   return {
-    fixture: { id, date: new Date(date) } as FixtureData["fixture"],
+    fixture: {
+      id,
+      date: new Date(date),
+      status: { long: "", short: statusShort, elapsed: null },
+    } as unknown as FixtureData["fixture"],
     teams: {
-      home: { ...home, logo: `${home.name}.png`, winner: null },
-      away: { ...away, logo: `${away.name}.png`, winner: null },
+      home: {
+        id: home.id,
+        name: home.name,
+        logo: `${home.name}.png`,
+        winner: home.winner ?? null,
+      },
+      away: {
+        id: away.id,
+        name: away.name,
+        logo: `${away.name}.png`,
+        winner: away.winner ?? null,
+      },
     },
   } as FixtureData
+}
+
+function makeStanding(rank: number, teamId: number, teamName: string): Standing {
+  return {
+    rank,
+    team: { id: teamId, name: teamName, logo: `${teamName}.png` },
+  } as Standing
 }
 
 describe("champion pick utils", () => {
@@ -106,22 +137,225 @@ describe("champion pick utils", () => {
       ])
     })
   })
+})
 
-  describe("getLeagueWinnerTeamId", () => {
-    it("returns winner id from current season", () => {
-      const league = {
-        seasons: [
-          { year: 2026, current: true, winner: { id: 10, name: "Brazil" } },
-        ],
-      }
-      expect(getLeagueWinnerTeamId(league)).toBe(10)
+describe("winner resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("isSeasonFinished", () => {
+    it("returns false for empty fixtures", () => {
+      expect(isSeasonFinished([])).toBe(false)
     })
 
-    it("returns null when no winner yet", () => {
-      const league = {
-        seasons: [{ year: 2026, current: true, winner: null }],
-      }
-      expect(getLeagueWinnerTeamId(league)).toBeNull()
+    it("returns false when a fixture is still open to play", () => {
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "FT"),
+        makeFixture(2, "2026-06-15T19:00:00Z", { id: 3, name: "C" }, { id: 4, name: "D" }, "NS"),
+      ]
+      expect(isSeasonFinished(fixtures)).toBe(false)
+    })
+
+    it("returns false when a fixture is in play", () => {
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "2H"),
+      ]
+      expect(isSeasonFinished(fixtures)).toBe(false)
+    })
+
+    it("returns true when all fixtures are finished", () => {
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "FT"),
+        makeFixture(2, "2026-06-15T19:00:00Z", { id: 3, name: "C" }, { id: 4, name: "D" }, "PEN"),
+      ]
+      expect(isSeasonFinished(fixtures)).toBe(true)
+    })
+  })
+
+  describe("getCupWinnerTeamId", () => {
+    it("returns the winning team of the chronologically last fixture", () => {
+      const fixtures = [
+        makeFixture(
+          2,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: true },
+          { id: 2, name: "France", winner: false },
+          "PEN"
+        ),
+        makeFixture(
+          1,
+          "2022-12-17T15:00:00Z",
+          { id: 7, name: "Croatia", winner: true },
+          { id: 31, name: "Morocco", winner: false },
+          "FT"
+        ),
+      ]
+      expect(getCupWinnerTeamId(fixtures)).toBe(26)
+    })
+
+    it("returns the away team when it won the final", () => {
+      const fixtures = [
+        makeFixture(
+          1,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: false },
+          { id: 2, name: "France", winner: true },
+          "FT"
+        ),
+      ]
+      expect(getCupWinnerTeamId(fixtures)).toBe(2)
+    })
+
+    it("returns null when the last fixture has no winner flag", () => {
+      const fixtures = [
+        makeFixture(
+          1,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina" },
+          { id: 2, name: "France" },
+          "NS"
+        ),
+      ]
+      expect(getCupWinnerTeamId(fixtures)).toBeNull()
+    })
+
+    it("returns null for empty fixtures", () => {
+      expect(getCupWinnerTeamId([])).toBeNull()
+    })
+
+    it("does not mutate the input fixtures order", () => {
+      const fixtures = [
+        makeFixture(
+          2,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: true },
+          { id: 2, name: "France", winner: false },
+          "PEN"
+        ),
+        makeFixture(
+          1,
+          "2022-12-17T15:00:00Z",
+          { id: 7, name: "Croatia", winner: true },
+          { id: 31, name: "Morocco", winner: false },
+          "FT"
+        ),
+      ]
+      getCupWinnerTeamId(fixtures)
+      expect(fixtures[0].fixture.id).toBe(2)
+    })
+  })
+
+  describe("getLeagueWinnerFromStandings", () => {
+    it("returns the rank 1 team of the first group", () => {
+      const standings: Standing[][] = [
+        [
+          makeStanding(2, 40, "Marseille"),
+          makeStanding(1, 85, "PSG"),
+          makeStanding(3, 80, "Lyon"),
+        ],
+      ]
+      expect(getLeagueWinnerFromStandings(standings)).toBe(85)
+    })
+
+    it("returns null for empty standings", () => {
+      expect(getLeagueWinnerFromStandings([])).toBeNull()
+    })
+
+    it("returns null when no rank 1 entry exists", () => {
+      const standings: Standing[][] = [[makeStanding(2, 40, "Marseille")]]
+      expect(getLeagueWinnerFromStandings(standings)).toBeNull()
+    })
+  })
+
+  describe("resolveChampionTeamId", () => {
+    it("returns null while the season is in progress and does not fetch standings", async () => {
+      const { fetchStandings } = await import("../data")
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "NS"),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "League",
+        leagueId: "61",
+        year: 2026,
+        fixtures,
+      })
+
+      expect(result).toBeNull()
+      expect(fetchStandings).not.toHaveBeenCalled()
+    })
+
+    it("resolves a cup winner from the final fixture without fetching standings", async () => {
+      const { fetchStandings } = await import("../data")
+      const fixtures = [
+        makeFixture(
+          1,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: true },
+          { id: 2, name: "France", winner: false },
+          "PEN"
+        ),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "Cup",
+        leagueId: "1",
+        year: 2022,
+        fixtures,
+      })
+
+      expect(result).toBe(26)
+      expect(fetchStandings).not.toHaveBeenCalled()
+    })
+
+    it("resolves a league winner from standings when the season is finished", async () => {
+      const { fetchStandings } = await import("../data")
+      vi.mocked(fetchStandings).mockResolvedValue({
+        standings: [[makeStanding(1, 85, "PSG"), makeStanding(2, 40, "Marseille")]],
+      } as any)
+
+      const fixtures = [
+        makeFixture(1, "2026-05-20T19:00:00Z", { id: 85, name: "PSG" }, { id: 40, name: "Marseille" }, "FT"),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "League",
+        leagueId: "61",
+        year: 2025,
+        fixtures,
+      })
+
+      expect(result).toBe(85)
+      expect(fetchStandings).toHaveBeenCalledWith({ leagueId: "61", year: 2025 })
+    })
+
+    it("returns null when standings are unavailable", async () => {
+      const { fetchStandings } = await import("../data")
+      vi.mocked(fetchStandings).mockResolvedValue([] as any)
+
+      const fixtures = [
+        makeFixture(1, "2026-05-20T19:00:00Z", { id: 85, name: "PSG" }, { id: 40, name: "Marseille" }, "FT"),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "League",
+        leagueId: "61",
+        year: 2025,
+        fixtures,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it("returns null for empty fixtures", async () => {
+      const result = await resolveChampionTeamId({
+        leagueType: "Cup",
+        leagueId: "1",
+        year: 2022,
+        fixtures: [],
+      })
+      expect(result).toBeNull()
     })
   })
 })

--- a/app/lib/__tests__/championPick.test.ts
+++ b/app/lib/__tests__/championPick.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import {
+  isChampionPickLocked,
+  getChampionPickLockDate,
+  getTeamsFromFixtures,
+} from "../utils"
+import { getLeagueWinnerTeamId } from "../championPick"
+import type { FixtureData } from "../definitions"
+
+function makeFixture(
+  id: number,
+  date: string,
+  home: { id: number; name: string },
+  away: { id: number; name: string }
+): FixtureData {
+  return {
+    fixture: { id, date: new Date(date) } as FixtureData["fixture"],
+    teams: {
+      home: { ...home, logo: `${home.name}.png`, winner: null },
+      away: { ...away, logo: `${away.name}.png`, winner: null },
+    },
+  } as FixtureData
+}
+
+describe("champion pick utils", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe("getChampionPickLockDate", () => {
+    it("returns earliest fixture date", () => {
+      const fixtures = [
+        makeFixture(
+          2,
+          "2026-06-15T19:00:00Z",
+          { id: 1, name: "B" },
+          { id: 2, name: "C" }
+        ),
+        makeFixture(
+          1,
+          "2026-06-11T19:00:00Z",
+          { id: 3, name: "A" },
+          { id: 4, name: "D" }
+        ),
+      ]
+      expect(getChampionPickLockDate(fixtures)).toEqual(
+        new Date("2026-06-11T19:00:00Z")
+      )
+    })
+
+    it("returns null for empty fixtures", () => {
+      expect(getChampionPickLockDate([])).toBeNull()
+    })
+  })
+
+  describe("isChampionPickLocked", () => {
+    it("returns false before earliest kickoff", () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-10T12:00:00Z"))
+      const fixtures = [
+        makeFixture(
+          1,
+          "2026-06-11T19:00:00Z",
+          { id: 1, name: "A" },
+          { id: 2, name: "B" }
+        ),
+      ]
+      expect(isChampionPickLocked(fixtures)).toBe(false)
+    })
+
+    it("returns true at or after earliest kickoff", () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-11T19:00:00Z"))
+      const fixtures = [
+        makeFixture(
+          1,
+          "2026-06-11T19:00:00Z",
+          { id: 1, name: "A" },
+          { id: 2, name: "B" }
+        ),
+      ]
+      expect(isChampionPickLocked(fixtures)).toBe(true)
+    })
+  })
+
+  describe("getTeamsFromFixtures", () => {
+    it("dedupes and sorts teams alphabetically", () => {
+      const fixtures = [
+        makeFixture(
+          1,
+          "2026-06-11T19:00:00Z",
+          { id: 10, name: "Mexico" },
+          { id: 20, name: "Brazil" }
+        ),
+        makeFixture(
+          2,
+          "2026-06-12T19:00:00Z",
+          { id: 10, name: "Mexico" },
+          { id: 30, name: "Argentina" }
+        ),
+      ]
+      expect(getTeamsFromFixtures(fixtures)).toEqual([
+        { id: 30, name: "Argentina", logo: "Argentina.png" },
+        { id: 20, name: "Brazil", logo: "Brazil.png" },
+        { id: 10, name: "Mexico", logo: "Mexico.png" },
+      ])
+    })
+  })
+
+  describe("getLeagueWinnerTeamId", () => {
+    it("returns winner id from current season", () => {
+      const league = {
+        seasons: [
+          { year: 2026, current: true, winner: { id: 10, name: "Brazil" } },
+        ],
+      }
+      expect(getLeagueWinnerTeamId(league)).toBe(10)
+    })
+
+    it("returns null when no winner yet", () => {
+      const league = {
+        seasons: [{ year: 2026, current: true, winner: null }],
+      }
+      expect(getLeagueWinnerTeamId(league)).toBeNull()
+    })
+  })
+})

--- a/app/lib/__tests__/controllerBet.test.ts
+++ b/app/lib/__tests__/controllerBet.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { getData } from "../controllerBet"
 import type { Bolao, UserBolao, Bet, FixtureData } from "@/app/lib/definitions"
 
-// Mock data fetching functions
 vi.mock("@/app/lib/data", () => ({
-  fetchBolao: vi.fn(),
-  fetchUserBolao: vi.fn(),
+  fetchBetPageContext: vi.fn(),
   fetchUsersBolao: vi.fn(),
   fetchRounds: vi.fn(),
   fetchFixtures: vi.fn(),
@@ -16,7 +14,10 @@ vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(),
 }))
 
-// Mock utility functions — keep pickCurrentRoundFromApiCurrent real so it exercises the mock cleanRounds
+vi.mock("@/app/lib/authRole", () => ({
+  getUserRole: vi.fn(),
+}))
+
 vi.mock("@/app/lib/utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/app/lib/utils")>()
   return {
@@ -68,7 +69,7 @@ describe("controllerBet", () => {
       logo: "logo.png",
       flag: "flag.png",
       season: 2024,
-      round: "Group A - 1",
+      round: "Round 2",
     },
     teams: {
       home: { id: 1, name: "Team A", logo: "teamA.png", winner: null },
@@ -91,98 +92,83 @@ describe("controllerBet", () => {
       value: 2,
       type: "home",
     },
-    {
-      id: "bet-2",
-      user_bolao_id: "ub-1",
-      fixture_id: "2",
-      value: 1,
-      type: "away",
-    },
   ]
 
   const mockRounds = ["Round 1", "Round 2", "Round 3", "Round 4"]
 
-  beforeEach(() => {
+  const fixtureForRound = (round: string, id = 1): FixtureData => ({
+    ...mockFixture,
+    fixture: { ...mockFixture.fixture, id },
+    league: { ...mockFixture.league, round },
+  })
+
+  async function setupDefaultMocks(options?: {
+    userRole?: string
+    bolao?: Bolao
+    fixtures?: FixtureData[]
+    currentRound?: string[]
+  }) {
+    const {
+      fetchBetPageContext,
+      fetchRounds,
+      fetchFixtures,
+      fetchUserBets,
+    } = await import("@/app/lib/data")
+    const { getUserRole } = await import("@/app/lib/authRole")
+
+    vi.mocked(getUserRole).mockResolvedValue(options?.userRole ?? "user")
+    vi.mocked(fetchBetPageContext).mockResolvedValue({
+      bolao: options?.bolao ?? mockBolao,
+      userBolao: mockUserBolao,
+      championPick: null,
+    })
+    vi.mocked(fetchRounds)
+      .mockResolvedValueOnce(mockRounds)
+      .mockResolvedValueOnce(options?.currentRound ?? ["Round 2"])
+    vi.mocked(fetchFixtures).mockResolvedValue(
+      options?.fixtures ?? mockRounds.map((round, index) => fixtureForRound(round, index + 1))
+    )
+    vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
+  }
+
+  beforeEach(async () => {
     vi.clearAllMocks()
+    await setupDefaultMocks()
   })
 
   describe("getData", () => {
-    it("should fetch and return all required data without roundParam", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds)
-        .mockResolvedValueOnce(mockRounds)
-        .mockResolvedValueOnce(["Round 2"])
-      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture])
-      vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
-
+    it("returns bet page data without roundParam", async () => {
       const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
 
       expect(result.bolao).toEqual(mockBolao)
       expect(result.userBolao).toEqual(mockUserBolao)
-      expect(result.allRounds).toEqual(mockRounds)
       expect(result.currentRound).toBe("Round 2")
-      expect(result.fixtures).toEqual([mockFixture])
+      expect(result.fixtures).toEqual([fixtureForRound("Round 2", 2)])
       expect(result.bets).toEqual(mockBets)
+      expect(result.isAdmin).toBe(false)
     })
 
-    it("should fetch bolao and userBolao in parallel", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
+    it("loads bet page context in one query", async () => {
+      const { fetchBetPageContext } = await import("@/app/lib/data")
 
       await getData({ bolaoId: "bolao-1", userId: "user-1" })
 
-      expect(fetchBolao).toHaveBeenCalledWith("bolao-1")
-      expect(fetchUserBolao).toHaveBeenCalledWith({
+      expect(fetchBetPageContext).toHaveBeenCalledWith({
         bolaoId: "bolao-1",
         userId: "user-1",
       })
     })
 
-    it("should fetch user bets with userBolaoId", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
-
-      await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(fetchUserBets).toHaveBeenCalledWith("ub-1")
-    })
-
-    it("should default admin bet data to the current user's userBolao", async () => {
-      const {
-        fetchBolao,
-        fetchUserBolao,
-        fetchUsersBolao,
-        fetchRounds,
-        fetchFixtures,
-        fetchUserBets,
-      } = await import("@/app/lib/data")
+    it("loads admin player data when user role is admin in Clerk", async () => {
+      const { fetchUsersBolao } = await import("@/app/lib/data")
+      const { getUserRole } = await import("@/app/lib/authRole")
       const { clerkClient } = await import("@clerk/nextjs/server")
 
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
+      await setupDefaultMocks({ userRole: "admin" })
       vi.mocked(fetchUsersBolao).mockResolvedValue([
         mockUserBolao,
         mockOtherUserBolao,
       ] as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
       vi.mocked(clerkClient).mockResolvedValue({
         users: {
           getUserList: vi.fn().mockResolvedValue({
@@ -192,11 +178,6 @@ describe("controllerBet", () => {
                 username: "kevin",
                 emailAddresses: [{ emailAddress: "kevin@example.com" }],
               },
-              {
-                id: "user-2",
-                username: "other",
-                emailAddresses: [{ emailAddress: "other@example.com" }],
-              },
             ],
           }),
         },
@@ -205,434 +186,83 @@ describe("controllerBet", () => {
       const result = await getData({
         bolaoId: "bolao-1",
         userId: "user-1",
-        isAdmin: true,
-      })
-
-      expect(fetchUsersBolao).toHaveBeenCalledWith("bolao-1")
-      expect(fetchUserBets).toHaveBeenCalledWith("ub-1")
-      expect(result.userBolao).toEqual(mockUserBolao)
-      expect(result.players).toEqual([
-        {
-          id: "user-1",
-          username: "kevin",
-          email: "kevin@example.com",
-          userBolaoId: "ub-1",
-        },
-        {
-          id: "user-2",
-          username: "other",
-          email: "other@example.com",
-          userBolaoId: "ub-2",
-        },
-      ])
-    })
-
-    it("should load selected player bets for admins when the player belongs to the bolao", async () => {
-      const {
-        fetchBolao,
-        fetchUserBolao,
-        fetchUsersBolao,
-        fetchRounds,
-        fetchFixtures,
-        fetchUserBets,
-      } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchUsersBolao).mockResolvedValue([
-        mockUserBolao,
-        mockOtherUserBolao,
-      ] as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
-      vi.mocked(clerkClient).mockResolvedValue({
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      } as any)
-
-      const result = await getData({
-        bolaoId: "bolao-1",
-        userId: "user-1",
-        isAdmin: true,
         selectedUserBolaoId: "ub-2",
       })
 
-      expect(fetchUserBets).toHaveBeenCalledWith("ub-2")
+      expect(result.isAdmin).toBe(true)
+      expect(getUserRole).toHaveBeenCalledWith("user-1")
+      expect(fetchUsersBolao).toHaveBeenCalledWith("bolao-1")
       expect(result.userBolao).toEqual(mockOtherUserBolao)
     })
 
-    it("should ignore selected player ids that do not belong to the bolao", async () => {
-      const {
-        fetchBolao,
-        fetchUserBolao,
-        fetchUsersBolao,
-        fetchRounds,
-        fetchFixtures,
-        fetchUserBets,
-      } = await import("@/app/lib/data")
-      const { clerkClient } = await import("@clerk/nextjs/server")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchUsersBolao).mockResolvedValue([
-        mockUserBolao,
-        mockOtherUserBolao,
-      ] as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue(mockBets)
-      vi.mocked(clerkClient).mockResolvedValue({
-        users: {
-          getUserList: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      } as any)
-
-      const result = await getData({
-        bolaoId: "bolao-1",
-        userId: "user-1",
-        isAdmin: true,
-        selectedUserBolaoId: "other-bolao-user",
-      })
-
-      expect(fetchUserBets).toHaveBeenCalledWith("ub-1")
-      expect(result.userBolao).toEqual(mockUserBolao)
-    })
-
-    it("should fetch rounds with correct parameters", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(fetchRounds).toHaveBeenCalledWith({
-        leagueId: "2",
-        year: 2024,
-      })
-      expect(fetchRounds).toHaveBeenCalledWith({
-        leagueId: "2",
-        year: 2024,
-        current: true,
-      })
-    })
-
-    it("should use cleanRounds utility on fetched rounds", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-      const { cleanRounds } = await import("@/app/lib/utils")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(cleanRounds).toHaveBeenCalledWith(mockRounds)
-    })
-
-    it("should use sortFixtures utility on fetched fixtures", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-      const { sortFixtures } = await import("@/app/lib/utils")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(sortFixtures).toHaveBeenCalledWith([mockFixture])
-    })
-
-    it("should use last element of currentRoundObj for current round", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds)
-        .mockResolvedValueOnce(mockRounds)
-        .mockResolvedValueOnce(["Round 2", "Round 3"]) // Multiple current rounds
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(result.currentRound).toBe("Round 3") // Last element
-    })
-
-    it("should fallback to last round when currentRoundObj is empty", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds)
-        .mockResolvedValueOnce(mockRounds)
-        .mockResolvedValueOnce([]) // Empty current round
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(result.currentRound).toBe("Round 4") // Last round
-    })
-
-    it("should handle roundParam and use it for pagination", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({
-        bolaoId: "bolao-1",
-        userId: "user-1",
-        roundParam: "2",
-      })
-
-      expect(result.currentRound).toBe("Round 2")
-      expect(fetchFixtures).toHaveBeenCalledWith({
-        leagueId: "2",
-        year: 2024,
-        round: "Round 2",
-      })
-    })
-
-    it("should set isFirstRound correctly when roundParam is 1", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({
-        bolaoId: "bolao-1",
-        userId: "user-1",
-        roundParam: "1",
-      })
-
-      expect(result.isFirstRound).toBe(true)
-      expect(result.isLastRound).toBe(false)
-      expect(result.currentRound).toBe("Round 1")
-    })
-
-    it("should set isLastRound correctly when roundParam is last round", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({
-        bolaoId: "bolao-1",
-        userId: "user-1",
-        roundParam: "4",
-      })
-
-      expect(result.isFirstRound).toBe(false)
-      expect(result.isLastRound).toBe(true)
-      expect(result.currentRound).toBe("Round 4")
-    })
-
-    it("should handle middle round correctly", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
+    it("handles roundParam pagination", async () => {
       const result = await getData({
         bolaoId: "bolao-1",
         userId: "user-1",
         roundParam: "3",
       })
 
-      expect(result.isFirstRound).toBe(false)
-      expect(result.isLastRound).toBe(false)
       expect(result.currentRound).toBe("Round 3")
-    })
-
-    it("should set isFirstRound and isLastRound when no roundParam and currentRound is first", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds)
-        .mockResolvedValueOnce(mockRounds)
-        .mockResolvedValueOnce(["Round 1"]) // Current round is first
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(result.isFirstRound).toBe(true)
+      expect(result.fixtures).toEqual([fixtureForRound("Round 3", 3)])
+      expect(result.isFirstRound).toBe(false)
       expect(result.isLastRound).toBe(false)
     })
 
-    it("should set isFirstRound and isLastRound when no roundParam and currentRound is last", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds)
-        .mockResolvedValueOnce(mockRounds)
-        .mockResolvedValueOnce(["Round 4"]) // Current round is last
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(result.isFirstRound).toBe(false)
-      expect(result.isLastRound).toBe(true)
-    })
-
-    it("should fetch fixtures with correct round parameter", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds)
-        .mockResolvedValueOnce(mockRounds)
-        .mockResolvedValueOnce(["Round 3"])
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
+    it("fetches season fixtures once", async () => {
+      const { fetchFixtures } = await import("@/app/lib/data")
 
       await getData({ bolaoId: "bolao-1", userId: "user-1" })
 
+      expect(fetchFixtures).toHaveBeenCalledTimes(1)
       expect(fetchFixtures).toHaveBeenCalledWith({
         leagueId: "2",
         year: 2024,
-        round: "Round 3",
       })
     })
 
-    it("should propagate errors from fetchBolao", async () => {
-      const { fetchBolao } = await import("@/app/lib/data")
-      const error = new Error("Failed to fetch bolao")
+    it("includes champion pick metadata", async () => {
+      const { fetchBetPageContext } = await import("@/app/lib/data")
 
-      vi.mocked(fetchBolao).mockRejectedValue(error)
-
-      await expect(
-        getData({ bolaoId: "bolao-1", userId: "user-1" })
-      ).rejects.toThrow("Failed to fetch bolao")
-    })
-
-    it("should propagate errors from fetchUserBolao", async () => {
-      const { fetchBolao, fetchUserBolao } = await import("@/app/lib/data")
-      const error = new Error("Failed to fetch user bolao")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockRejectedValue(error)
-
-      await expect(
-        getData({ bolaoId: "bolao-1", userId: "user-1" })
-      ).rejects.toThrow("Failed to fetch user bolao")
-    })
-
-    it("should propagate errors from fetchUserBets", async () => {
-      const { fetchBolao, fetchUserBolao, fetchUserBets } = await import(
-        "@/app/lib/data"
-      )
-      const error = new Error("Failed to fetch bets")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchUserBets).mockRejectedValue(error)
-
-      await expect(
-        getData({ bolaoId: "bolao-1", userId: "user-1" })
-      ).rejects.toThrow("Failed to fetch bets")
-    })
-
-    it("should handle multiple fixtures", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      const multipleFixtures = [
-        mockFixture,
-        { ...mockFixture, fixture: { ...mockFixture.fixture, id: 2 } },
-        { ...mockFixture, fixture: { ...mockFixture.fixture, id: 3 } },
-      ]
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue(multipleFixtures)
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(result.fixtures).toHaveLength(3)
-    })
-
-    it("should handle empty bets array", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(result.bets).toHaveLength(0)
-    })
-
-    it("should extract year and leagueId from bolao", async () => {
-      const { fetchBolao, fetchUserBolao, fetchRounds, fetchFixtures, fetchUserBets } =
-        await import("@/app/lib/data")
-
-      const customBolao = { ...mockBolao, year: 2023, competition_id: "39" }
-
-      vi.mocked(fetchBolao).mockResolvedValue(customBolao as any)
-      vi.mocked(fetchUserBolao).mockResolvedValue(mockUserBolao as any)
-      vi.mocked(fetchRounds).mockResolvedValue(mockRounds)
-      vi.mocked(fetchFixtures).mockResolvedValue([])
-      vi.mocked(fetchUserBets).mockResolvedValue([])
-
-      await getData({ bolaoId: "bolao-1", userId: "user-1" })
-
-      expect(fetchRounds).toHaveBeenCalledWith({
-        leagueId: "39",
-        year: 2023,
+      vi.mocked(fetchBetPageContext).mockResolvedValue({
+        bolao: mockBolao,
+        userBolao: mockUserBolao,
+        championPick: {
+          id: "cp-1",
+          user_bolao_id: "ub-1",
+          team_id: 10,
+          team_name: "Brazil",
+          team_logo: "b.png",
+          created_at: "",
+          updated_at: "",
+        },
       })
-      expect(fetchFixtures).toHaveBeenCalledWith(
-        expect.objectContaining({
-          leagueId: "39",
-          year: 2023,
-        })
+
+      const result = await getData({ bolaoId: "bolao-1", userId: "user-1" })
+
+      expect(result.userChampionPick?.team_name).toBe("Brazil")
+      expect(result.championPickTeams.length).toBeGreaterThan(0)
+    })
+
+    it("propagates bet page context errors", async () => {
+      const { fetchBetPageContext } = await import("@/app/lib/data")
+
+      vi.mocked(fetchBetPageContext).mockRejectedValue(
+        new Error("Failed to fetch bet page context.")
       )
+
+      await expect(
+        getData({ bolaoId: "bolao-1", userId: "user-1" })
+      ).rejects.toThrow("Failed to fetch bet page context.")
+    })
+
+    it("throws when user is not a member", async () => {
+      const { fetchBetPageContext } = await import("@/app/lib/data")
+
+      vi.mocked(fetchBetPageContext).mockResolvedValue(null)
+
+      await expect(
+        getData({ bolaoId: "bolao-1", userId: "user-1" })
+      ).rejects.toThrow("User is not a member of this bolao.")
     })
   })
 })
-

--- a/app/lib/__tests__/controllerLead.test.ts
+++ b/app/lib/__tests__/controllerLead.test.ts
@@ -14,6 +14,8 @@ vi.mock("@/app/lib/data", () => ({
   fetchUsersBolao: vi.fn(),
   fetchFixtures: vi.fn(),
   fetchUsersBets: vi.fn(),
+  fetchChampionPicks: vi.fn(),
+  fetchLeague: vi.fn(),
 }))
 
 // Mock Clerk client
@@ -88,8 +90,13 @@ describe("controllerLead", () => {
     },
   ]
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
+    const { fetchChampionPicks, fetchLeague } = await import("@/app/lib/data")
+    vi.mocked(fetchChampionPicks).mockResolvedValue([])
+    vi.mocked(fetchLeague).mockResolvedValue({
+      seasons: [{ year: 2024, current: true, winner: null }],
+    } as any)
   })
 
   describe("getData", () => {

--- a/app/lib/__tests__/controllerLead.test.ts
+++ b/app/lib/__tests__/controllerLead.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/app/lib/data", () => ({
   fetchUsersBets: vi.fn(),
   fetchChampionPicks: vi.fn(),
   fetchLeague: vi.fn(),
+  fetchStandings: vi.fn(),
 }))
 
 // Mock Clerk client
@@ -92,11 +93,15 @@ describe("controllerLead", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    const { fetchChampionPicks, fetchLeague } = await import("@/app/lib/data")
+    const { fetchChampionPicks, fetchLeague, fetchStandings } = await import(
+      "@/app/lib/data"
+    )
     vi.mocked(fetchChampionPicks).mockResolvedValue([])
     vi.mocked(fetchLeague).mockResolvedValue({
-      seasons: [{ year: 2024, current: true, winner: null }],
+      league: { id: 2, name: "Champions League", type: "Cup" },
+      seasons: [{ year: 2024, current: true }],
     } as any)
+    vi.mocked(fetchStandings).mockResolvedValue([] as any)
   })
 
   describe("getData", () => {
@@ -305,6 +310,120 @@ describe("controllerLead", () => {
       const result = await getData({ bolaoId: "bolao-1" })
 
       expect(result.fixtures).toHaveLength(3)
+    })
+
+    it("should resolve a cup winner from the final fixture", async () => {
+      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
+        await import("@/app/lib/data")
+      const { clerkClient } = await import("@clerk/nextjs/server")
+
+      const mockClient = {
+        users: {
+          getUserList: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      }
+
+      const finalFixture: FixtureData = {
+        ...mockFixture,
+        fixture: {
+          ...mockFixture.fixture,
+          id: 2,
+          date: new Date("2024-06-01"),
+          status: { long: "Match Finished", short: "PEN", elapsed: 120 },
+        },
+        teams: {
+          home: { id: 26, name: "Argentina", logo: "arg.png", winner: true },
+          away: { id: 2, name: "France", logo: "fra.png", winner: false },
+        },
+      }
+
+      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
+      vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
+      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture, finalFixture])
+      vi.mocked(fetchUsersBets).mockResolvedValue([])
+      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+
+      const result = await getData({ bolaoId: "bolao-1" })
+
+      expect(result.leagueWinnerTeamId).toBe(26)
+    })
+
+    it("should resolve a league winner from standings when the season is finished", async () => {
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchLeague,
+        fetchStandings,
+      } = await import("@/app/lib/data")
+      const { clerkClient } = await import("@clerk/nextjs/server")
+
+      const mockClient = {
+        users: {
+          getUserList: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      }
+
+      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
+      vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
+      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture])
+      vi.mocked(fetchUsersBets).mockResolvedValue([])
+      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchLeague).mockResolvedValue({
+        league: { id: 61, name: "Ligue 1", type: "League" },
+        seasons: [{ year: 2024, current: true }],
+      } as any)
+      vi.mocked(fetchStandings).mockResolvedValue({
+        standings: [
+          [
+            { rank: 1, team: { id: 85, name: "PSG", logo: "psg.png" } },
+            { rank: 2, team: { id: 80, name: "Lyon", logo: "lyon.png" } },
+          ],
+        ],
+      } as any)
+
+      const result = await getData({ bolaoId: "bolao-1" })
+
+      expect(result.leagueWinnerTeamId).toBe(85)
+      expect(fetchStandings).toHaveBeenCalledWith({ leagueId: "2", year: 2024 })
+    })
+
+    it("should return null winner while the season is in progress without fetching standings", async () => {
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchStandings,
+      } = await import("@/app/lib/data")
+      const { clerkClient } = await import("@clerk/nextjs/server")
+
+      const mockClient = {
+        users: {
+          getUserList: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      }
+
+      const upcomingFixture: FixtureData = {
+        ...mockFixture,
+        fixture: {
+          ...mockFixture.fixture,
+          id: 3,
+          status: { long: "Not Started", short: "NS", elapsed: null as any },
+        },
+      }
+
+      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
+      vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
+      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture, upcomingFixture])
+      vi.mocked(fetchUsersBets).mockResolvedValue([])
+      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+
+      const result = await getData({ bolaoId: "bolao-1" })
+
+      expect(result.leagueWinnerTeamId).toBeNull()
+      expect(fetchStandings).not.toHaveBeenCalled()
     })
 
     it("should propagate errors from fetchBolao", async () => {

--- a/app/lib/__tests__/fetchBetPageContext.test.ts
+++ b/app/lib/__tests__/fetchBetPageContext.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@vercel/postgres", () => ({
+  sql: vi.fn(),
+}))
+
+import { sql } from "@vercel/postgres"
+import { fetchBetPageContext } from "../data"
+
+describe("fetchBetPageContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    console.error = vi.fn()
+  })
+
+  it("returns combined bolao, membership, and champion pick", async () => {
+    vi.mocked(sql).mockResolvedValue({
+      rows: [
+        {
+          id: "bolao-1",
+          name: "Copa 2026",
+          competition_id: "1",
+          created_by: "user-1",
+          created_at: new Date("2024-01-01"),
+          year: 2026,
+          start: "2026-06-01",
+          end: "2026-07-15",
+          user_bolao_id: "ub-1",
+          bolao_id: "bolao-1",
+          user_id: "user-1",
+          champion_pick_id: "cp-1",
+          team_id: 10,
+          team_name: "Brazil",
+          team_logo: "b.png",
+          champion_pick_created_at: "2026-06-01",
+          champion_pick_updated_at: "2026-06-01",
+        },
+      ],
+    } as any)
+
+    await expect(fetchBetPageContext({ bolaoId: "bolao-1", userId: "user-1" }))
+      .resolves.toEqual({
+        bolao: {
+          id: "bolao-1",
+          name: "Copa 2026",
+          competition_id: "1",
+          created_by: "user-1",
+          created_at: new Date("2024-01-01"),
+          year: 2026,
+          start: "2026-06-01",
+          end: "2026-07-15",
+        },
+        userBolao: {
+          id: "ub-1",
+          bolao_id: "bolao-1",
+          user_id: "user-1",
+        },
+        championPick: {
+          id: "cp-1",
+          user_bolao_id: "ub-1",
+          team_id: 10,
+          team_name: "Brazil",
+          team_logo: "b.png",
+          created_at: "2026-06-01",
+          updated_at: "2026-06-01",
+        },
+      })
+  })
+
+  it("returns null when user is not in bolao", async () => {
+    vi.mocked(sql).mockResolvedValue({ rows: [] } as any)
+
+    await expect(
+      fetchBetPageContext({ bolaoId: "bolao-1", userId: "user-1" })
+    ).resolves.toBeNull()
+  })
+})

--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -4,13 +4,15 @@ import { sql } from "@vercel/postgres"
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
 import { auth } from "@clerk/nextjs/server"
-import { fetchLeague } from "./data"
-import { getCurrentSeasonObject } from "./utils"
+import { fetchLeague, fetchBolao, fetchFixtures } from "./data"
+import { getCurrentSeasonObject, isChampionPickLocked } from "./utils"
 import {
   BetResult,
   UpdateBolaoResult,
   CreateUserBolaoResult,
   CreateBolaoResult,
+  ChampionPickResult,
+  ChampionPick,
 } from "./definitions"
 
 export async function createUser({ id, role }: { id: string; role: string }) {
@@ -200,6 +202,65 @@ export async function updateBet({
     return {
       message: "Database Error: failed to set a bet.",
     } as BetResult
+  }
+}
+
+export async function createOrUpdateChampionPick({
+  userBolaoId,
+  bolaoId,
+  teamId,
+  teamName,
+  teamLogo,
+}: {
+  userBolaoId: string
+  bolaoId: string
+  teamId: number
+  teamName: string
+  teamLogo: string
+}): Promise<ChampionPickResult> {
+  const { userId } = await auth()
+
+  if (!userId) {
+    return { success: false, message: "Unauthorized." }
+  }
+
+  try {
+    const bolao = await fetchBolao(bolaoId)
+    const fixtures = await fetchFixtures({
+      leagueId: bolao.competition_id,
+      year: bolao.year,
+    })
+
+    if (isChampionPickLocked(fixtures)) {
+      return { success: false, message: "Champion pick is locked." }
+    }
+
+    const result = await sql`
+      INSERT INTO champion_picks (user_bolao_id, team_id, team_name, team_logo)
+      SELECT ub.id, ${teamId}, ${teamName}, ${teamLogo}
+      FROM user_bolao ub
+      WHERE CAST(ub.id AS VARCHAR) = ${userBolaoId}
+        AND CAST(ub.bolao_id AS VARCHAR) = ${bolaoId}
+        AND CAST(ub.user_id AS VARCHAR) = ${userId}
+      ON CONFLICT (user_bolao_id) DO UPDATE SET
+        team_id = EXCLUDED.team_id,
+        team_name = EXCLUDED.team_name,
+        team_logo = EXCLUDED.team_logo,
+        updated_at = NOW()
+      RETURNING *
+    `
+
+    if (!result.rows[0]) {
+      return { success: false, message: "Forbidden." }
+    }
+
+    return { ...(result.rows[0] as ChampionPick), success: true }
+  } catch (error) {
+    console.log(error)
+    return {
+      success: false,
+      message: "Database Error: failed to save champion pick.",
+    }
   }
 }
 

--- a/app/lib/authRole.ts
+++ b/app/lib/authRole.ts
@@ -1,0 +1,13 @@
+import { clerkClient } from "@clerk/nextjs/server"
+
+export async function getUserRole(userId: string): Promise<string> {
+  try {
+    const client = await clerkClient()
+    const userData = await client.users.getUser(userId)
+    const role = userData.privateMetadata?.role
+    return typeof role === "string" ? role : "guest"
+  } catch (error) {
+    console.error("Failed to fetch user role from Clerk:", error)
+    return "guest"
+  }
+}

--- a/app/lib/calcLeadFactory.ts
+++ b/app/lib/calcLeadFactory.ts
@@ -1,6 +1,11 @@
-import { Bet, FixtureData, PlayersData } from "./definitions"
+import { Bet, FixtureData, PlayersData, ChampionPick, LeadData } from "./definitions"
 import { calcScore } from "./scoresCalcFactory"
-import { STATUSES_FINISHED, findBetObj, getEmailUsername } from "./utils"
+import {
+  STATUSES_FINISHED,
+  findBetObj,
+  getEmailUsername,
+  CHAMPION_PICK_BONUS_POINTS,
+} from "./utils"
 
 const getTotal = ({
   fixtures,
@@ -49,25 +54,59 @@ export const calcLead = ({
   players,
   fixtures,
   bets,
+  championPicks = [],
+  leagueWinnerTeamId = null,
 }: {
   players: PlayersData[]
   fixtures: FixtureData[]
   bets: Bet[]
+  championPicks?: ChampionPick[]
+  leagueWinnerTeamId?: number | null
 }) => {
-  const lead: any = []
+  const picksByUserBolaoId = new Map(
+    championPicks.map((pick) => [pick.user_bolao_id, pick])
+  )
+
+  const lead: {
+    name: string
+    total: number
+    championPick?: { id: number; name: string; logo: string } | null
+  }[] = []
 
   players.forEach((player: PlayersData) => {
-    let total = 0
-
     const totalMatchDay = getTotal({ bets, fixtures, player })
+    const pick = picksByUserBolaoId.get(player.userBolaoId)
+    const championBonus =
+      leagueWinnerTeamId !== null && pick?.team_id === leagueWinnerTeamId
+        ? CHAMPION_PICK_BONUS_POINTS
+        : 0
 
-    total = total + totalMatchDay
-
-    lead.push({
+    const entry: {
+      name: string
+      total: number
+      championPick?: { id: number; name: string; logo: string } | null
+    } = {
       name: player.username || getEmailUsername(player.email),
-      total,
-    })
+      total: totalMatchDay + championBonus,
+    }
+
+    if (championPicks.length > 0) {
+      entry.championPick = pick
+        ? { id: pick.team_id, name: pick.team_name, logo: pick.team_logo }
+        : null
+    }
+
+    lead.push(entry)
   })
 
   return lead
+}
+
+export function prepareLeadForDisplay(
+  lead: LeadData[],
+  isChampionPickLocked: boolean
+): LeadData[] {
+  if (isChampionPickLocked) return lead
+
+  return lead.map((entry) => ({ ...entry, championPick: null }))
 }

--- a/app/lib/championPick.ts
+++ b/app/lib/championPick.ts
@@ -1,14 +1,67 @@
-type LeagueSeason = {
+import { FixtureData, Standing } from "./definitions"
+import { fetchStandings } from "./data"
+import {
+  sortFixtures,
+  STATUSES_OPEN_TO_PLAY,
+  STATUSES_IN_PLAY,
+} from "./utils"
+
+export function isSeasonFinished(fixtures: FixtureData[]): boolean {
+  if (fixtures.length === 0) return false
+
+  return fixtures.every(
+    (fixture) =>
+      !STATUSES_OPEN_TO_PLAY.includes(fixture.fixture.status.short) &&
+      !STATUSES_IN_PLAY.includes(fixture.fixture.status.short)
+  )
+}
+
+// Cup-style competitions (World Cup, Champions League...) are decided by the
+// chronologically last fixture: the API flags its winner even after penalties.
+export function getCupWinnerTeamId(fixtures: FixtureData[]): number | null {
+  if (fixtures.length === 0) return null
+
+  const sorted = sortFixtures([...fixtures])
+  const finalFixture = sorted[sorted.length - 1]
+
+  if (finalFixture.teams.home.winner === true) return finalFixture.teams.home.id
+  if (finalFixture.teams.away.winner === true) return finalFixture.teams.away.id
+
+  return null
+}
+
+export function getLeagueWinnerFromStandings(
+  standings: Standing[][]
+): number | null {
+  const firstGroup = standings[0]
+  if (!firstGroup) return null
+
+  const leader = firstGroup.find((standing) => standing.rank === 1)
+  return leader?.team.id ?? null
+}
+
+export async function resolveChampionTeamId({
+  leagueType,
+  leagueId,
+  year,
+  fixtures,
+}: {
+  leagueType: string | undefined
+  leagueId: string
   year: number
-  current: boolean
-  winner?: { id: number; name: string } | null
-}
+  fixtures: FixtureData[]
+}): Promise<number | null> {
+  if (!isSeasonFinished(fixtures)) return null
 
-type LeagueResponse = {
-  seasons: LeagueSeason[]
-}
+  if (leagueType === "Cup") {
+    return getCupWinnerTeamId(fixtures)
+  }
 
-export function getLeagueWinnerTeamId(league: LeagueResponse): number | null {
-  const currentSeason = league.seasons.find((season) => season.current)
-  return currentSeason?.winner?.id ?? null
+  // Points-based leagues (Premier League, Ligue 1...): rank 1 of the final standings.
+  const standingsLeague = await fetchStandings({ leagueId, year })
+  const standings: Standing[][] | undefined = standingsLeague?.standings
+
+  if (!Array.isArray(standings)) return null
+
+  return getLeagueWinnerFromStandings(standings)
 }

--- a/app/lib/championPick.ts
+++ b/app/lib/championPick.ts
@@ -1,0 +1,14 @@
+type LeagueSeason = {
+  year: number
+  current: boolean
+  winner?: { id: number; name: string } | null
+}
+
+type LeagueResponse = {
+  seasons: LeagueSeason[]
+}
+
+export function getLeagueWinnerTeamId(league: LeagueResponse): number | null {
+  const currentSeason = league.seasons.find((season) => season.current)
+  return currentSeason?.winner?.id ?? null
+}

--- a/app/lib/controllerBet.ts
+++ b/app/lib/controllerBet.ts
@@ -1,6 +1,5 @@
 import {
-  fetchBolao,
-  fetchUserBolao,
+  fetchBetPageContext,
   fetchUsersBolao,
   fetchRounds,
   fetchFixtures,
@@ -10,28 +9,43 @@ import {
   sortFixtures,
   cleanRounds,
   pickCurrentRoundFromApiCurrent,
+  isChampionPickLocked,
+  getChampionPickLockDate,
+  getTeamsFromFixtures,
 } from "@/app/lib/utils"
-import { Bet, PlayersData, UserBolao } from "@/app/lib/definitions"
+import { Bet, FixtureData, PlayersData, UserBolao } from "@/app/lib/definitions"
+import { getUserRole } from "./authRole"
 import { getPlayersFromUsersBolao } from "./players"
+
+function filterFixturesByRound(
+  fixtures: FixtureData[],
+  round: string
+): FixtureData[] {
+  return fixtures.filter(
+    (fixture) => fixture.league.round.toLowerCase() === round.toLowerCase()
+  )
+}
 
 export async function getData({
   bolaoId,
   roundParam,
   userId,
-  isAdmin = false,
   selectedUserBolaoId,
 }: {
   bolaoId: string
   roundParam?: string
   userId: string
-  isAdmin?: boolean
   selectedUserBolaoId?: string
 }) {
-  const [bolao, userBolao] = await Promise.all([
-    fetchBolao(bolaoId),
-    fetchUserBolao({ bolaoId, userId }),
-  ])
+  const context = await fetchBetPageContext({ bolaoId, userId })
 
+  if (!context) {
+    throw new Error("User is not a member of this bolao.")
+  }
+
+  const { bolao, userBolao, championPick: userChampionPick } = context
+  const userRole = await getUserRole(userId)
+  const isAdmin = userRole === "admin"
   const year: number = bolao.year
   const leagueId: string = bolao.competition_id
 
@@ -46,16 +60,15 @@ export async function getData({
       usersBolao.find((el) => el.id === selectedUserBolaoId) || userBolao
   }
 
-  const bets: Bet[] = await fetchUserBets(selectedUserBolao.id)
+  const [bets, allSeasonFixtures, allRoundsUncleaned, currentRoundObj] =
+    await Promise.all([
+      fetchUserBets(selectedUserBolao.id),
+      fetchFixtures({ leagueId, year }),
+      fetchRounds({ leagueId, year }),
+      fetchRounds({ leagueId, year, current: true }),
+    ])
 
-  const allRoundsUncleaned: string[] = await fetchRounds({ leagueId, year }) // HAS TO GO TO STORE
   const allRounds: string[] = cleanRounds(allRoundsUncleaned)
-
-  const currentRoundObj: string[] = await fetchRounds({
-    leagueId,
-    year,
-    current: true,
-  }) // HAS TO GO TO STORE
   const currentRound = pickCurrentRoundFromApiCurrent(
     currentRoundObj,
     allRounds,
@@ -65,8 +78,6 @@ export async function getData({
   let isFirstRound: boolean = false
   let isLastRound: boolean = false
 
-  // PARAM HANDLING FOR PAGINATION
-  // We use round as an index because there are spaces in the round names
   let round = currentRound
 
   if (roundParam) {
@@ -79,19 +90,15 @@ export async function getData({
     isFirstRound = currentRound === allRounds[0]
     isLastRound = currentRound === allRounds[allRounds.length - 1]
   }
-  // END
 
-  const unSortedFixtures = await fetchFixtures({
-    leagueId,
-    year,
-    round,
-  })
-  const fixtures = sortFixtures(unSortedFixtures)
+  const fixtures = sortFixtures(filterFixturesByRound(allSeasonFixtures, round))
 
   return {
     bolao,
     userBolao: selectedUserBolao,
     currentUserBolao: userBolao,
+    userRole,
+    isAdmin,
     currentRound: round,
     allRounds,
     fixtures,
@@ -99,5 +106,9 @@ export async function getData({
     isFirstRound,
     bets,
     players,
+    championPickTeams: getTeamsFromFixtures(allSeasonFixtures),
+    isChampionPickLocked: isChampionPickLocked(allSeasonFixtures),
+    championPickLockDate: getChampionPickLockDate(allSeasonFixtures),
+    userChampionPick,
   }
 }

--- a/app/lib/controllerLead.ts
+++ b/app/lib/controllerLead.ts
@@ -8,7 +8,7 @@ import {
 } from "@/app/lib/data"
 import { FixtureData, UserBolao, Bet } from "./definitions"
 import { getPlayersFromUsersBolao } from "./players"
-import { getLeagueWinnerTeamId } from "./championPick"
+import { resolveChampionTeamId } from "./championPick"
 import { isChampionPickLocked } from "./utils"
 
 export async function getData({ bolaoId }: { bolaoId: string }) {
@@ -31,6 +31,13 @@ export async function getData({ bolaoId }: { bolaoId: string }) {
     fetchLeague(Number(leagueId)),
   ])
 
+  const leagueWinnerTeamId = await resolveChampionTeamId({
+    leagueType: league?.league?.type,
+    leagueId,
+    year,
+    fixtures,
+  })
+
   return {
     bolao,
     fixtures: fixtures as FixtureData[],
@@ -38,6 +45,6 @@ export async function getData({ bolaoId }: { bolaoId: string }) {
     bets,
     championPicks,
     isChampionPickLocked: isChampionPickLocked(fixtures),
-    leagueWinnerTeamId: getLeagueWinnerTeamId(league),
+    leagueWinnerTeamId,
   }
 }

--- a/app/lib/controllerLead.ts
+++ b/app/lib/controllerLead.ts
@@ -3,9 +3,13 @@ import {
   fetchUsersBolao,
   fetchFixtures,
   fetchUsersBets,
+  fetchChampionPicks,
+  fetchLeague,
 } from "@/app/lib/data"
 import { FixtureData, UserBolao, Bet } from "./definitions"
 import { getPlayersFromUsersBolao } from "./players"
+import { getLeagueWinnerTeamId } from "./championPick"
+import { isChampionPickLocked } from "./utils"
 
 export async function getData({ bolaoId }: { bolaoId: string }) {
   const [bolao, usersBolao] = await Promise.all([
@@ -18,17 +22,22 @@ export async function getData({ bolaoId }: { bolaoId: string }) {
 
   const players = await getPlayersFromUsersBolao(usersBolao)
 
-  // Fetch all fixtures
-  const fixtures: FixtureData[] = await fetchFixtures({ leagueId, year })
-
-  // Fetch bets
   const userBoloesIds: string[] = usersBolao.map((el: UserBolao) => el.id)
-  const bets: Bet[] = await fetchUsersBets(userBoloesIds)
+
+  const [fixtures, bets, championPicks, league] = await Promise.all([
+    fetchFixtures({ leagueId, year }),
+    fetchUsersBets(userBoloesIds),
+    fetchChampionPicks(userBoloesIds),
+    fetchLeague(Number(leagueId)),
+  ])
 
   return {
     bolao,
-    fixtures,
+    fixtures: fixtures as FixtureData[],
     players,
     bets,
+    championPicks,
+    isChampionPickLocked: isChampionPickLocked(fixtures),
+    leagueWinnerTeamId: getLeagueWinnerTeamId(league),
   }
 }

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -3,7 +3,7 @@
 import { QueryResultRow } from "pg"
 import { sql } from "@vercel/postgres"
 import { FOOTBALL_API_SPORTS } from "./utils"
-import { Bolao, Bet, User } from "./definitions"
+import { Bolao, Bet, User, ChampionPick, BetPageContext } from "./definitions"
 import { FOOTBALL_API_SPORTS_LEAGUES } from "./utils"
 
 export async function fetchBoloes() {
@@ -343,5 +343,120 @@ export async function fetchStandings({
     return data.response[0].league
   } else {
     return []
+  }
+}
+
+export async function fetchBetPageContext({
+  bolaoId,
+  userId,
+}: {
+  bolaoId: string
+  userId: string
+}): Promise<BetPageContext | null> {
+  if (!userId || !bolaoId) {
+    throw new Error("Missing userid or bolaoId")
+  }
+
+  try {
+    const data = await sql`
+      SELECT
+        b.id,
+        b.name,
+        b.competition_id,
+        b.created_by,
+        b.created_at,
+        b.year,
+        b.start,
+        b.end,
+        ub.id AS user_bolao_id,
+        ub.bolao_id,
+        ub.user_id,
+        cp.id AS champion_pick_id,
+        cp.team_id,
+        cp.team_name,
+        cp.team_logo,
+        cp.created_at AS champion_pick_created_at,
+        cp.updated_at AS champion_pick_updated_at
+      FROM boloes b
+      INNER JOIN user_bolao ub
+        ON CAST(b.id AS VARCHAR) = CAST(ub.bolao_id AS VARCHAR)
+      LEFT JOIN champion_picks cp
+        ON CAST(cp.user_bolao_id AS VARCHAR) = CAST(ub.id AS VARCHAR)
+      WHERE CAST(b.id AS VARCHAR) = ${bolaoId}
+        AND CAST(ub.user_id AS VARCHAR) = ${userId}
+    `
+
+    const row = data.rows[0]
+    if (!row) return null
+
+    const championPick = row.champion_pick_id
+      ? ({
+          id: row.champion_pick_id as string,
+          user_bolao_id: row.user_bolao_id as string,
+          team_id: row.team_id as number,
+          team_name: row.team_name as string,
+          team_logo: row.team_logo as string,
+          created_at: row.champion_pick_created_at as string,
+          updated_at: row.champion_pick_updated_at as string,
+        } satisfies ChampionPick)
+      : null
+
+    return {
+      bolao: {
+        id: row.id as string,
+        name: row.name as string,
+        competition_id: row.competition_id as string,
+        created_by: row.created_by as string,
+        created_at: row.created_at as Date,
+        year: row.year as number,
+        start: row.start as string | undefined,
+        end: row.end as string | undefined,
+      },
+      userBolao: {
+        id: row.user_bolao_id as string,
+        bolao_id: row.bolao_id as string,
+        user_id: row.user_id as string,
+      },
+      championPick,
+    }
+  } catch (error) {
+    console.error("Database Error:", error)
+    throw new Error("Failed to fetch bet page context.")
+  }
+}
+
+export async function fetchChampionPick(
+  userBolaoId: string
+): Promise<ChampionPick | null> {
+  if (!userBolaoId) return null
+
+  try {
+    const data = await sql`
+      SELECT * FROM champion_picks
+      WHERE CAST(user_bolao_id AS VARCHAR) = ${userBolaoId}
+    `
+
+    return (data.rows[0] as ChampionPick) ?? null
+  } catch (error) {
+    console.error("Database Error:", error)
+    throw new Error("Failed to fetch champion pick.")
+  }
+}
+
+export async function fetchChampionPicks(
+  userBolaoIds: string[]
+): Promise<ChampionPick[]> {
+  if (!userBolaoIds.length) return []
+
+  try {
+    const data = await sql`
+      SELECT * FROM champion_picks
+      WHERE CAST(user_bolao_id AS VARCHAR) = ANY(${userBolaoIds as any})
+    `
+
+    return data.rows as ChampionPick[]
+  } catch (error) {
+    console.error("Database Error:", error)
+    throw new Error("Failed to fetch champion picks.")
   }
 }

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -84,7 +84,7 @@ type Team = {
   id: number
   name: string
   logo: string
-  winner: unknown
+  winner: boolean | null
 }
 
 export type ScoreGroup = {

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -46,6 +46,12 @@ export type UserBolao = {
   user_id: string
 }
 
+export type BetPageContext = {
+  bolao: Bolao
+  userBolao: UserBolao
+  championPick: ChampionPick | null
+}
+
 type SuccessBolaoResult = {
   success: boolean
 }
@@ -158,6 +164,26 @@ export type Bet = {
   type: "away" | "home"
 }
 
+export type ChampionTeam = {
+  id: number
+  name: string
+  logo: string
+}
+
+export type ChampionPick = {
+  id: string
+  user_bolao_id: string
+  team_id: number
+  team_name: string
+  team_logo: string
+  created_at: string
+  updated_at: string
+}
+
+type SuccessChampionPickResult = ChampionPick & { success: true }
+
+export type ChampionPickResult = SuccessChampionPickResult | ErrorResult
+
 export type StandingsLeague = {
   id: number
   name: string
@@ -219,6 +245,7 @@ export type ScoreArgs = {
 export type LeadData = {
   name: string
   total: number
+  championPick?: ChampionTeam | null
 }
 
 export type League = {

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Season, FixtureData, Bet } from "./definitions"
+import { Season, FixtureData, Bet, ChampionTeam } from "./definitions"
 import { format } from "date-fns"
 import { enUS, ptBR } from "date-fns/locale"
 
@@ -91,6 +91,30 @@ export const getCurrentSeasonObject = (
   return seasons.find((el: Season) => el.current)
 }
 
+export function getChampionPickLockDate(fixtures: FixtureData[]): Date | null {
+  if (fixtures.length === 0) return null
+  const sorted = sortFixtures([...fixtures])
+  return new Date(sorted[0].fixture.date)
+}
+
+export function isChampionPickLocked(fixtures: FixtureData[]): boolean {
+  const lockDate = getChampionPickLockDate(fixtures)
+  if (!lockDate) return false
+  return Date.now() >= lockDate.getTime()
+}
+
+export function getTeamsFromFixtures(fixtures: FixtureData[]): ChampionTeam[] {
+  const byId = new Map<number, ChampionTeam>()
+  for (const fixture of fixtures) {
+    for (const team of [fixture.teams.home, fixture.teams.away]) {
+      if (!byId.has(team.id)) {
+        byId.set(team.id, { id: team.id, name: team.name, logo: team.logo })
+      }
+    }
+  }
+  return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+
 export const sortFixtures = (fixtures: FixtureData[]) => {
   return fixtures.sort((a, b) => {
     const dateA = new Date(a.fixture.date).getTime()
@@ -153,6 +177,8 @@ export function pickCurrentRoundFromApiCurrent(
     ""
   )
 }
+
+export const CHAMPION_PICK_BONUS_POINTS = 500
 
 export const INITIAL_BET_VALUE = "."
 

--- a/app/ui/bolao/bet/__tests__/championPickSelector.test.tsx
+++ b/app/ui/bolao/bet/__tests__/championPickSelector.test.tsx
@@ -75,7 +75,7 @@ describe("ChampionPickSelector", () => {
   it("renders label and team options", () => {
     render(<ChampionPickSelector {...baseProps} />)
 
-    expect(screen.getByText("Winner (+500 pts)")).toBeInTheDocument()
+    expect(screen.getByText("Winner (+500 pts) — beta")).toBeInTheDocument()
     expect(screen.getByRole("option", { name: "Brazil" })).toBeInTheDocument()
     expect(screen.getByRole("option", { name: "Mexico" })).toBeInTheDocument()
   })

--- a/app/ui/bolao/bet/__tests__/championPickSelector.test.tsx
+++ b/app/ui/bolao/bet/__tests__/championPickSelector.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import ChampionPickSelector from "../championPickSelector"
+import type { ChampionPick, ChampionTeam } from "@/app/lib/definitions"
+
+const mockCreateOrUpdateChampionPick = vi.fn()
+
+vi.mock("@/app/lib/actions", () => ({
+  createOrUpdateChampionPick: (...args: unknown[]) =>
+    mockCreateOrUpdateChampionPick(...args),
+}))
+
+const mockToast = vi.fn()
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value?: string
+    onValueChange: (value: string) => void
+    disabled?: boolean
+    children: React.ReactNode
+  }) => (
+    <select
+      aria-label="Select championship winner"
+      value={value ?? ""}
+      disabled={disabled}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string
+    children: React.ReactNode
+  }) => <option value={value}>{children}</option>,
+}))
+
+describe("ChampionPickSelector", () => {
+  const teams: ChampionTeam[] = [
+    { id: 10, name: "Brazil", logo: "brazil.png" },
+    { id: 20, name: "Mexico", logo: "mexico.png" },
+  ]
+
+  const baseProps = {
+    bolaoId: "bolao-1",
+    userBolaoId: "ub-1",
+    teams,
+    userChampionPick: null,
+    isLocked: false,
+    lockDate: new Date("2026-06-11T19:00:00Z"),
+    leagueWinnerTeamId: null,
+    locale: "en",
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateOrUpdateChampionPick.mockResolvedValue({ success: true })
+  })
+
+  it("renders label and team options", () => {
+    render(<ChampionPickSelector {...baseProps} />)
+
+    expect(screen.getByText("Winner (+500 pts)")).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Brazil" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Mexico" })).toBeInTheDocument()
+  })
+
+  it("calls createOrUpdateChampionPick when a team is selected", async () => {
+    const user = userEvent.setup()
+    render(<ChampionPickSelector {...baseProps} />)
+
+    await user.selectOptions(
+      screen.getByLabelText("Select championship winner"),
+      "10"
+    )
+
+    expect(mockCreateOrUpdateChampionPick).toHaveBeenCalledWith({
+      userBolaoId: "ub-1",
+      bolaoId: "bolao-1",
+      teamId: 10,
+      teamName: "Brazil",
+      teamLogo: "brazil.png",
+    })
+  })
+
+  it("hides the selector when locked", () => {
+    const { container } = render(
+      <ChampionPickSelector {...baseProps} isLocked={true} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("returns null when there are no teams", () => {
+    const { container } = render(
+      <ChampionPickSelector {...baseProps} teams={[]} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("shows success toast when pick is saved", async () => {
+    const user = userEvent.setup()
+    render(<ChampionPickSelector {...baseProps} />)
+
+    await user.selectOptions(
+      screen.getByLabelText("Select championship winner"),
+      "10"
+    )
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "success",
+        title: "Pick saved",
+        description: "Brazil is your championship winner pick.",
+      })
+    )
+    expect(screen.getByText(/You picked Brazil/)).toBeInTheDocument()
+  })
+
+  it("shows current pick as selected value", () => {
+    const userChampionPick: ChampionPick = {
+      id: "cp-1",
+      user_bolao_id: "ub-1",
+      team_id: 20,
+      team_name: "Mexico",
+      team_logo: "mexico.png",
+      created_at: "",
+      updated_at: "",
+    }
+
+    render(
+      <ChampionPickSelector
+        {...baseProps}
+        userChampionPick={userChampionPick}
+      />
+    )
+
+    expect(screen.getByLabelText("Select championship winner")).toHaveValue("20")
+  })
+})

--- a/app/ui/bolao/bet/championPickSelector.tsx
+++ b/app/ui/bolao/bet/championPickSelector.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useState } from "react"
+import { useTranslations } from "next-intl"
+import { ChampionTeam, ChampionPick } from "@/app/lib/definitions"
+import { createOrUpdateChampionPick } from "@/app/lib/actions"
+import { formatDateFixtures } from "@/app/lib/utils"
+import { useToast } from "@/hooks/use-toast"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+type Props = {
+  bolaoId: string
+  userBolaoId: string
+  teams: ChampionTeam[]
+  userChampionPick: ChampionPick | null
+  isLocked: boolean
+  lockDate: Date | null
+  leagueWinnerTeamId: number | null
+  locale: string
+}
+
+function ChampionPickSelector({
+  bolaoId,
+  userBolaoId,
+  teams,
+  userChampionPick,
+  isLocked,
+  lockDate,
+  leagueWinnerTeamId,
+  locale,
+}: Props) {
+  const t = useTranslations("championPick")
+  const { toast } = useToast()
+  const [savedPick, setSavedPick] = useState<ChampionTeam | null>(
+    userChampionPick
+      ? {
+          id: userChampionPick.team_id,
+          name: userChampionPick.team_name,
+          logo: userChampionPick.team_logo,
+        }
+      : null
+  )
+  const [selectedTeamId, setSelectedTeamId] = useState(
+    userChampionPick ? String(userChampionPick.team_id) : undefined
+  )
+  const [isSaving, setIsSaving] = useState(false)
+
+  const handleChange = async (teamIdStr: string) => {
+    const team = teams.find((entry) => entry.id === Number(teamIdStr))
+    if (!team || isSaving) return
+
+    setSelectedTeamId(teamIdStr)
+    setIsSaving(true)
+
+    try {
+      const result = await createOrUpdateChampionPick({
+        userBolaoId,
+        bolaoId,
+        teamId: team.id,
+        teamName: team.name,
+        teamLogo: team.logo,
+      })
+
+      if (result.success) {
+        setSavedPick(team)
+        toast({
+          variant: "success",
+          title: t("saveSuccessTitle"),
+          description: t("saveSuccessDescription", { team: team.name }),
+        })
+      } else {
+        setSelectedTeamId(savedPick ? String(savedPick.id) : undefined)
+        toast({
+          variant: "destructive",
+          title: t("saveErrorTitle"),
+          description: result.message,
+        })
+      }
+    } catch {
+      setSelectedTeamId(savedPick ? String(savedPick.id) : undefined)
+      toast({
+        variant: "destructive",
+        title: t("saveErrorTitle"),
+        description: t("saveErrorDescription"),
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const getStatusLine = (): string => {
+    if (leagueWinnerTeamId !== null) {
+      const winnerTeam = teams.find((team) => team.id === leagueWinnerTeamId)
+      const winnerName = winnerTeam?.name ?? String(leagueWinnerTeamId)
+
+      if (savedPick?.id === leagueWinnerTeamId) {
+        return t("statusWon", { team: winnerName })
+      }
+
+      return t("statusLost", { team: winnerName })
+    }
+
+    if (isLocked) {
+      return t("statusLocked")
+    }
+
+    if (savedPick) {
+      return t("statusUnlockedHasPick", {
+        team: savedPick.name,
+        date: lockDate ? formatDateFixtures(lockDate.toISOString(), locale) : "",
+      })
+    }
+
+    return t("statusUnlockedNoPick")
+  }
+
+  if (teams.length === 0 || isLocked) return null
+
+  return (
+    <div className="mb-4 flex justify-center">
+      <div className="w-full max-w-xs">
+        <div className="mb-1 text-xs font-medium text-muted-foreground">
+          {t("label")}
+        </div>
+        <Select
+          value={selectedTeamId}
+          onValueChange={handleChange}
+          disabled={isLocked || isSaving}
+        >
+          <SelectTrigger aria-label={t("selectTeam")}>
+            <SelectValue placeholder={t("placeholder")} />
+          </SelectTrigger>
+          <SelectContent>
+            {teams.map((team) => (
+              <SelectItem key={team.id} value={String(team.id)}>
+                {team.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="mt-1 text-xs text-muted-foreground">{getStatusLine()}</p>
+      </div>
+    </div>
+  )
+}
+
+export default ChampionPickSelector

--- a/app/ui/bolao/lead/__tests__/tableLead.test.tsx
+++ b/app/ui/bolao/lead/__tests__/tableLead.test.tsx
@@ -4,7 +4,10 @@ import TableLead from "../tableLead"
 import type { LeadData } from "@/app/lib/definitions"
 
 // Helper to render async server component
-async function renderTableLead(props: { data: LeadData[] }) {
+async function renderTableLead(props: {
+  data: LeadData[]
+  isChampionPickLocked?: boolean
+}) {
   const Component = await TableLead(props)
   return render(Component)
 }
@@ -218,16 +221,16 @@ describe("TableLead", () => {
       expect(tbody).toBeInTheDocument()
     })
 
-    it("should have correct number of columns", async () => {
+    it("should have five columns including winner pick", async () => {
       const mockData: LeadData[] = [{ name: "Player", total: 100 }]
 
       const { container } = await renderTableLead({ data: mockData })
 
       const headerCells = container.querySelectorAll("thead th")
-      expect(headerCells).toHaveLength(4) // rank, player, score, needs
+      expect(headerCells).toHaveLength(5)
 
       const bodyCells = container.querySelectorAll("tbody tr:first-child td")
-      expect(bodyCells).toHaveLength(4)
+      expect(bodyCells).toHaveLength(5)
     })
   })
 
@@ -353,6 +356,44 @@ describe("TableLead", () => {
 
       // Card components render proper semantic structure
       expect(screen.getByText("Players lead")).toBeInTheDocument()
+    })
+  })
+
+  describe("Champion pick column", () => {
+    it("shows pick names when locked", async () => {
+      const mockData: LeadData[] = [
+        {
+          name: "Alice",
+          total: 100,
+          championPick: { id: 10, name: "Brazil", logo: "b.png" },
+        },
+      ]
+
+      await renderTableLead({ data: mockData, isChampionPickLocked: true })
+
+      expect(screen.getByText("Winner pick")).toBeInTheDocument()
+      expect(screen.getByText("Brazil")).toBeInTheDocument()
+    })
+
+    it("shows a hyphen before lock even when picks exist", async () => {
+      const mockData: LeadData[] = [
+        {
+          name: "Alice",
+          total: 100,
+          championPick: { id: 10, name: "Brazil", logo: "b.png" },
+        },
+      ]
+
+      const { container } = await renderTableLead({
+        data: mockData,
+        isChampionPickLocked: false,
+      })
+
+      expect(screen.getByText("Winner pick")).toBeInTheDocument()
+      expect(screen.queryByText("Brazil")).not.toBeInTheDocument()
+
+      const winnerPickCell = container.querySelector("tbody tr:first-child td:nth-child(3)")
+      expect(winnerPickCell?.textContent).toBe("—")
     })
   })
 })

--- a/app/ui/bolao/lead/tableLead.tsx
+++ b/app/ui/bolao/lead/tableLead.tsx
@@ -7,10 +7,12 @@ const paddingVertical = "py-3"
 
 type TableProps = {
   data: LeadData[]
+  isChampionPickLocked?: boolean
 }
 
-async function TableLead({ data }: TableProps) {
+async function TableLead({ data, isChampionPickLocked = false }: TableProps) {
   const t = await getTranslations("leadPage")
+  const tChampion = await getTranslations("championPick")
 
   return (
     <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
@@ -19,61 +21,75 @@ async function TableLead({ data }: TableProps) {
           <CardTitle>{t("title")}</CardTitle>
         </CardHeader>
         <CardContent>
-        <table className="w-full text-xs">
-          <thead className="uppercase">
-            <tr>
-              <th className={paddingVertical} />
-              <th className={`${paddingVertical} text-left pl-2`}>{t("player")}</th>
-              <th className={`${paddingVertical} text-right`}>{t("score")}</th>
-              <th className={`${paddingVertical} text-right pr-3`}>{t("needs")}</th>
-            </tr>
-          </thead>
-          <tbody className="f7">
-            {data.map((player: any, playerIndex: number) => {
-              const missingPoints = data[0].total - player.total
+          <table className="w-full text-xs">
+            <thead className="uppercase">
+              <tr>
+                <th className={paddingVertical} />
+                <th className={`${paddingVertical} text-left pl-2`}>
+                  {t("player")}
+                </th>
+                <th className={`${paddingVertical} text-left pl-2`}>
+                  {tChampion("leadColumnHeader")}
+                </th>
+                <th className={`${paddingVertical} text-right`}>
+                  {t("score")}
+                </th>
+                <th className={`${paddingVertical} text-right pr-3`}>
+                  {t("needs")}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="f7">
+              {data.map((player: LeadData, playerIndex: number) => {
+                const missingPoints = data[0].total - player.total
 
-              return (
-                <tr
-                  key={playerIndex}
-                  className={clsx("py-5", {
-                    "bg-slate-50": playerIndex % 2 !== 0,
-                  })}
-                >
-                  <td className={`${paddingVertical} text-right`}>
-                    <span
-                      className={`${
-                        playerIndex === 0
-                          ? "gray-light"
-                          : playerIndex === 1
-                            ? "gray-medium"
-                            : "gray-dark"
-                      } f8`}
-                    >
-                      {(playerIndex + 1).toString().padStart(2, "0")}
-                    </span>
-                  </td>
-                  <td className={paddingVertical}>
-                    <span className="leadtable-playername ttc pl-2">
-                      {player.name}
-                    </span>
-                  </td>
-                  <td className={paddingVertical}>
-                    <div className="flex justify-end">{player.total}</div>
-                  </td>
-                  <td className={`${paddingVertical} pr-3`}>
-                    <div className="flex justify-end">
-                      {missingPoints === 0 ? (
-                        <span className="gray-light f8">-</span>
-                      ) : (
-                        missingPoints
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
+                return (
+                  <tr
+                    key={playerIndex}
+                    className={clsx("py-5", {
+                      "bg-slate-50": playerIndex % 2 !== 0,
+                    })}
+                  >
+                    <td className={`${paddingVertical} text-right`}>
+                      <span
+                        className={`${
+                          playerIndex === 0
+                            ? "gray-light"
+                            : playerIndex === 1
+                              ? "gray-medium"
+                              : "gray-dark"
+                        } f8`}
+                      >
+                        {(playerIndex + 1).toString().padStart(2, "0")}
+                      </span>
+                    </td>
+                    <td className={paddingVertical}>
+                      <span className="leadtable-playername ttc pl-2">
+                        {player.name}
+                      </span>
+                    </td>
+                    <td className={`${paddingVertical} pl-2`}>
+                      {isChampionPickLocked && player.championPick?.name
+                        ? player.championPick.name
+                        : tChampion("noPick")}
+                    </td>
+                    <td className={paddingVertical}>
+                      <div className="flex justify-end">{player.total}</div>
+                    </td>
+                    <td className={`${paddingVertical} pr-3`}>
+                      <div className="flex justify-end">
+                        {missingPoints === 0 ? (
+                          <span className="gray-light f8">-</span>
+                        ) : (
+                          missingPoints
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
     </div>

--- a/app/ui/news/newsList.tsx
+++ b/app/ui/news/newsList.tsx
@@ -7,9 +7,12 @@ import type { NewsDocument } from "@/prismicio-types"
 function NewsList({ documents }: { documents: NewsDocument[] }) {
   return (
     <>
-      {documents.map((document: any) => {
+      {documents.map((document: any, index: number) => {
         return (
-          <div className="mb-20" key={document.id}>
+          <div
+            className="mb-20"
+            key={document.id ?? document.uid ?? index}
+          >
             <h2 className="text-2xl">{document.data.title[0]?.text}</h2>
             <div className="text-sm mb-12 text-slate-500">
               {formatDateNews(document.first_publication_date)}

--- a/docs/superpowers/plans/2026-06-07-championship-winner-pick.md
+++ b/docs/superpowers/plans/2026-06-07-championship-winner-pick.md
@@ -1,0 +1,994 @@
+# Championship Winner Pick Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let each bolão member optionally pick a championship winner (+500 pts if correct), editable until the earliest season fixture kickoff, revealed on the Lead page after lock.
+
+**Architecture:** Dedicated `champion_picks` table with upsert server action. Lock/team-list helpers derived from all-season fixtures. Bet page uses a `PlayerSelector`-style Shadcn Select (stacked below admin selector). Lead page adds a "Winner pick" column after lock. Scoring extended in `calcLead` using League API season winner.
+
+**Tech Stack:** Next.js App Router, Vercel Postgres (`@vercel/postgres`), Clerk auth, api-football via existing `fetchFixtures`/`fetchLeague`, Vitest, next-intl, Shadcn Select.
+
+**Spec:** [`docs/superpowers/specs/2026-06-07-championship-winner-pick-design.md`](../specs/2026-06-07-championship-winner-pick-design.md)
+
+**Branch:** `feature/championship-winner-pick`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `scripts/seed.js` | `champion_picks` table DDL |
+| `app/lib/definitions.ts` | `ChampionPick`, `ChampionTeam`, result types; extend `LeadData` |
+| `app/lib/utils.ts` | `CHAMPION_PICK_BONUS_POINTS`, lock/team helpers |
+| `app/lib/championPick.ts` | `getLeagueWinnerTeamId` (League API winner extraction) |
+| `app/lib/data.ts` | `fetchChampionPick`, `fetchChampionPicks` |
+| `app/lib/actions.ts` | `createOrUpdateChampionPick` |
+| `app/lib/calcLeadFactory.ts` | Champion bonus in totals |
+| `app/lib/controllerBet.ts` | All-season fixtures + champion pick state for Bet page |
+| `app/lib/controllerLead.ts` | Champion picks + lock + winner for Lead page |
+| `app/ui/bolao/bet/championPickSelector.tsx` | Client Select component (mirrors `playerSelector.tsx`) |
+| `app/bolao/[id]/bet/page.tsx` | Render selector |
+| `app/ui/bolao/lead/tableLead.tsx` | Winner pick column |
+| `app/bolao/[id]/lead/page.tsx` | Pass champion data to table + calcLead |
+| `messages/en.json`, `messages/pt-br.json` | i18n strings |
+| `app/lib/__tests__/championPick.test.ts` | Utils + winner extraction tests |
+| `app/lib/__tests__/actions.test.ts` | Server action tests |
+| `app/lib/__tests__/calcLeadFactory.test.ts` | Bonus scoring tests |
+| `app/ui/bolao/bet/__tests__/championPickSelector.test.tsx` | Component tests |
+| `app/ui/bolao/lead/__tests__/tableLead.test.tsx` | Lead column tests |
+
+---
+
+### Task 1: Types and constants
+
+**Files:**
+- Modify: `app/lib/definitions.ts`
+- Modify: `app/lib/utils.ts`
+
+- [ ] **Step 1: Add types to `definitions.ts`**
+
+Add after the `Bet` type:
+
+```typescript
+export type ChampionTeam = {
+  id: number
+  name: string
+  logo: string
+}
+
+export type ChampionPick = {
+  id: string
+  user_bolao_id: string
+  team_id: number
+  team_name: string
+  team_logo: string
+  created_at: string
+  updated_at: string
+}
+
+type SuccessChampionPickResult = ChampionPick & { success: true }
+
+export type ChampionPickResult = SuccessChampionPickResult | ErrorResult
+
+export type LeadData = {
+  name: string
+  total: number
+  championPick?: ChampionTeam | null
+}
+```
+
+Remove the old inline `LeadData` type if it exists separately (merge into this shape).
+
+- [ ] **Step 2: Add constant to `utils.ts`**
+
+```typescript
+export const CHAMPION_PICK_BONUS_POINTS = 500
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `yarn build` (or `npx tsc --noEmit` if available)
+Expected: no new type errors from `LeadData` shape change — fix any call sites that break.
+
+- [ ] **Step 4: Commit** *(requires user approval per AGENTS.md)*
+
+```bash
+git add app/lib/definitions.ts app/lib/utils.ts
+git commit -m "feat: add champion pick types and bonus constant"
+```
+
+---
+
+### Task 2: Champion pick utilities (TDD)
+
+**Files:**
+- Create: `app/lib/__tests__/championPick.test.ts`
+- Modify: `app/lib/utils.ts`
+- Create: `app/lib/championPick.ts`
+
+- [ ] **Step 1: Write failing tests for lock + teams helpers**
+
+Create `app/lib/__tests__/championPick.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, afterEach } from "vitest"
+import {
+  isChampionPickLocked,
+  getChampionPickLockDate,
+  getTeamsFromFixtures,
+} from "../utils"
+import { getLeagueWinnerTeamId } from "../championPick"
+import type { FixtureData } from "../definitions"
+
+function makeFixture(
+  id: number,
+  date: string,
+  home: { id: number; name: string },
+  away: { id: number; name: string }
+): FixtureData {
+  return {
+    fixture: { id, date: new Date(date) } as FixtureData["fixture"],
+    teams: {
+      home: { ...home, logo: `${home.name}.png`, winner: null },
+      away: { ...away, logo: `${away.name}.png`, winner: null },
+    },
+  } as FixtureData
+}
+
+describe("champion pick utils", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe("getChampionPickLockDate", () => {
+    it("returns earliest fixture date", () => {
+      const fixtures = [
+        makeFixture(2, "2026-06-15T19:00:00Z", { id: 1, name: "B" }, { id: 2, name: "C" }),
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 3, name: "A" }, { id: 4, name: "D" }),
+      ]
+      expect(getChampionPickLockDate(fixtures)).toEqual(new Date("2026-06-11T19:00:00Z"))
+    })
+
+    it("returns null for empty fixtures", () => {
+      expect(getChampionPickLockDate([])).toBeNull()
+    })
+  })
+
+  describe("isChampionPickLocked", () => {
+    it("returns false before earliest kickoff", () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-10T12:00:00Z"))
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }),
+      ]
+      expect(isChampionPickLocked(fixtures)).toBe(false)
+    })
+
+    it("returns true at or after earliest kickoff", () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-11T19:00:00Z"))
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }),
+      ]
+      expect(isChampionPickLocked(fixtures)).toBe(true)
+    })
+  })
+
+  describe("getTeamsFromFixtures", () => {
+    it("dedupes and sorts teams alphabetically", () => {
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 10, name: "Mexico" }, { id: 20, name: "Brazil" }),
+        makeFixture(2, "2026-06-12T19:00:00Z", { id: 10, name: "Mexico" }, { id: 30, name: "Argentina" }),
+      ]
+      expect(getTeamsFromFixtures(fixtures)).toEqual([
+        { id: 30, name: "Argentina", logo: "Argentina.png" },
+        { id: 20, name: "Brazil", logo: "Brazil.png" },
+        { id: 10, name: "Mexico", logo: "Mexico.png" },
+      ])
+    })
+  })
+
+  describe("getLeagueWinnerTeamId", () => {
+    it("returns winner id from current season", () => {
+      const league = {
+        seasons: [
+          { year: 2026, current: true, winner: { id: 10, name: "Brazil" } },
+        ],
+      }
+      expect(getLeagueWinnerTeamId(league)).toBe(10)
+    })
+
+    it("returns null when no winner yet", () => {
+      const league = {
+        seasons: [
+          { year: 2026, current: true, winner: null },
+        ],
+      }
+      expect(getLeagueWinnerTeamId(league)).toBeNull()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test app/lib/__tests__/championPick.test.ts`
+Expected: FAIL — exports not found
+
+- [ ] **Step 3: Implement helpers in `utils.ts`**
+
+```typescript
+import { ChampionTeam, FixtureData } from "./definitions"
+
+export function getChampionPickLockDate(fixtures: FixtureData[]): Date | null {
+  if (fixtures.length === 0) return null
+  const sorted = sortFixtures([...fixtures])
+  return new Date(sorted[0].fixture.date)
+}
+
+export function isChampionPickLocked(fixtures: FixtureData[]): boolean {
+  const lockDate = getChampionPickLockDate(fixtures)
+  if (!lockDate) return false
+  return Date.now() >= lockDate.getTime()
+}
+
+export function getTeamsFromFixtures(fixtures: FixtureData[]): ChampionTeam[] {
+  const byId = new Map<number, ChampionTeam>()
+  for (const fixture of fixtures) {
+    for (const team of [fixture.teams.home, fixture.teams.away]) {
+      if (!byId.has(team.id)) {
+        byId.set(team.id, { id: team.id, name: team.name, logo: team.logo })
+      }
+    }
+  }
+  return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+```
+
+- [ ] **Step 4: Implement `app/lib/championPick.ts`**
+
+```typescript
+import { getCurrentSeasonObject } from "./utils"
+
+type LeagueSeason = {
+  year: number
+  current: boolean
+  winner?: { id: number; name: string } | null
+}
+
+type LeagueResponse = {
+  seasons: LeagueSeason[]
+}
+
+export function getLeagueWinnerTeamId(league: LeagueResponse): number | null {
+  const currentSeason = getCurrentSeasonObject(league.seasons as any)
+  return currentSeason?.winner?.id ?? null
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `yarn test app/lib/__tests__/championPick.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/utils.ts app/lib/championPick.ts app/lib/__tests__/championPick.test.ts
+git commit -m "feat: add champion pick lock and team list helpers"
+```
+
+---
+
+### Task 3: Database table
+
+**Files:**
+- Modify: `scripts/seed.js`
+
+- [ ] **Step 1: Add `seedChampionPicks` function**
+
+```javascript
+async function seedChampionPicks(client) {
+  try {
+    const createTable = await client.sql`
+      CREATE TABLE IF NOT EXISTS champion_picks (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        user_bolao_id VARCHAR(100) NOT NULL UNIQUE,
+        team_id INTEGER NOT NULL,
+        team_name VARCHAR(200) NOT NULL,
+        team_logo VARCHAR(500) NOT NULL,
+        created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+        updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+    `
+    console.log(`Created "champion_picks" table`)
+    return { createTable }
+  } catch (error) {
+    console.error("Error creating table champion_picks:", error)
+    throw error
+  }
+}
+```
+
+Call `await seedChampionPicks(client)` in `main()` after `seedBets`.
+
+- [ ] **Step 2: Run seed against dev DB** *(if POSTGRES env available)*
+
+Run: `node scripts/seed.js`
+Expected: `Created "champion_picks" table`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/seed.js
+git commit -m "feat: add champion_picks table to seed script"
+```
+
+---
+
+### Task 4: Data fetchers
+
+**Files:**
+- Modify: `app/lib/data.ts`
+- Modify: `app/lib/__tests__/data.test.ts` *(create if missing, or add to existing)*
+
+- [ ] **Step 1: Write failing tests**
+
+Add to a new or existing data test file:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@vercel/postgres", () => ({ sql: vi.fn() }))
+
+import { sql } from "@vercel/postgres"
+import { fetchChampionPick, fetchChampionPicks } from "../data"
+
+describe("champion pick data", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("fetchChampionPick returns row or null", async () => {
+    vi.mocked(sql).mockResolvedValue({
+      rows: [{ id: "cp-1", user_bolao_id: "ub-1", team_id: 10, team_name: "Brazil", team_logo: "b.png" }],
+    } as any)
+    const result = await fetchChampionPick("ub-1")
+    expect(result?.team_id).toBe(10)
+  })
+
+  it("fetchChampionPicks returns empty for empty input", async () => {
+    const result = await fetchChampionPicks([])
+    expect(result).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run test — verify FAIL**
+
+Run: `yarn test app/lib/__tests__/data.test.ts` *(adjust path to wherever tests land)*
+
+- [ ] **Step 3: Implement fetchers in `data.ts`**
+
+```typescript
+import { ChampionPick } from "./definitions"
+
+export async function fetchChampionPick(userBolaoId: string): Promise<ChampionPick | null> {
+  if (!userBolaoId) return null
+  try {
+    const data = await sql`
+      SELECT * FROM champion_picks
+      WHERE CAST(user_bolao_id AS VARCHAR) = ${userBolaoId}
+    `
+    return (data.rows[0] as ChampionPick) ?? null
+  } catch (error) {
+    console.error("Database Error:", error)
+    throw new Error("Failed to fetch champion pick.")
+  }
+}
+
+export async function fetchChampionPicks(userBolaoIds: string[]): Promise<ChampionPick[]> {
+  if (!userBolaoIds.length) return []
+  try {
+    const data = await sql`
+      SELECT * FROM champion_picks
+      WHERE CAST(user_bolao_id AS VARCHAR) = ANY(${userBolaoIds as any})
+    `
+    return data.rows as ChampionPick[]
+  } catch (error) {
+    console.error("Database Error:", error)
+    throw new Error("Failed to fetch champion picks.")
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — verify PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/data.ts app/lib/__tests__/data.test.ts
+git commit -m "feat: add champion pick data fetchers"
+```
+
+---
+
+### Task 5: Server action (TDD)
+
+**Files:**
+- Modify: `app/lib/actions.ts`
+- Modify: `app/lib/__tests__/actions.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add a new `describe("createOrUpdateChampionPick")` block. Mock:
+- `@clerk/nextjs/server` → `auth` returns `{ userId: "user-1" }`
+- `../data` → `fetchUserBolao`, `fetchFixtures`
+- `../utils` → `isChampionPickLocked`
+
+Test cases:
+1. Rejects when not authenticated
+2. Rejects when user doesn't own `userBolaoId`
+3. Rejects when locked
+4. Upserts successfully when unlocked
+
+Example success test skeleton:
+
+```typescript
+it("upserts champion pick when unlocked", async () => {
+  vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as any)
+  vi.mocked(fetchUserBolao).mockResolvedValue({ id: "ub-1", user_id: "user-1" } as any)
+  vi.mocked(fetchFixtures).mockResolvedValue([/* fixture before lock */] as any)
+  vi.mocked(isChampionPickLocked).mockReturnValue(false)
+  vi.mocked(sql).mockResolvedValue({
+    rows: [{ id: "cp-1", user_bolao_id: "ub-1", team_id: 10, team_name: "Brazil", team_logo: "b.png", success: true }],
+  } as any)
+
+  const result = await createOrUpdateChampionPick({
+    userBolaoId: "ub-1",
+    bolaoId: "bolao-1",
+    teamId: 10,
+    teamName: "Brazil",
+    teamLogo: "b.png",
+  })
+
+  expect(result.success).toBe(true)
+})
+```
+
+- [ ] **Step 2: Run tests — verify FAIL**
+
+- [ ] **Step 3: Implement `createOrUpdateChampionPick` in `actions.ts`**
+
+```typescript
+import {
+  fetchUserBolao,
+  fetchBolao,
+  fetchFixtures,
+} from "./data"
+import {
+  isChampionPickLocked,
+} from "./utils"
+import { ChampionPickResult } from "./definitions"
+
+export async function createOrUpdateChampionPick({
+  userBolaoId,
+  bolaoId,
+  teamId,
+  teamName,
+  teamLogo,
+}: {
+  userBolaoId: string
+  bolaoId: string
+  teamId: number
+  teamName: string
+  teamLogo: string
+}): Promise<ChampionPickResult> {
+  const { userId } = await auth()
+  if (!userId) {
+    return { success: false, message: "Unauthorized." }
+  }
+
+  const userBolao = await fetchUserBolao({ bolaoId, userId })
+  if (!userBolao || userBolao.id !== userBolaoId) {
+    return { success: false, message: "Forbidden." }
+  }
+
+  const bolao = await fetchBolao(bolaoId)
+  const allFixtures = await fetchFixtures({
+    leagueId: bolao.competition_id,
+    year: bolao.year,
+  })
+
+  if (isChampionPickLocked(allFixtures)) {
+    return { success: false, message: "Champion pick is locked." }
+  }
+
+  try {
+    const result = await sql`
+      INSERT INTO champion_picks (user_bolao_id, team_id, team_name, team_logo)
+      VALUES (${userBolaoId}, ${teamId}, ${teamName}, ${teamLogo})
+      ON CONFLICT (user_bolao_id) DO UPDATE SET
+        team_id = EXCLUDED.team_id,
+        team_name = EXCLUDED.team_name,
+        team_logo = EXCLUDED.team_logo,
+        updated_at = NOW()
+      RETURNING *
+    `
+    return { ...result.rows[0], success: true }
+  } catch (error) {
+    console.log(error)
+    return { success: false, message: "Database Error: failed to save champion pick." }
+  }
+}
+```
+
+Add `revalidatePath(\`/bolao/${bolaoId}/bet\`)` and `revalidatePath(\`/bolao/${bolaoId}/lead\`)` on success.
+
+Update test mocks at top of `actions.test.ts` to include new data imports.
+
+- [ ] **Step 4: Run tests — verify PASS**
+
+Run: `yarn test app/lib/__tests__/actions.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/actions.ts app/lib/__tests__/actions.test.ts
+git commit -m "feat: add createOrUpdateChampionPick server action"
+```
+
+---
+
+### Task 6: Scoring (TDD)
+
+**Files:**
+- Modify: `app/lib/calcLeadFactory.ts`
+- Modify: `app/lib/__tests__/calcLeadFactory.test.ts`
+
+- [ ] **Step 1: Write failing test for champion bonus**
+
+```typescript
+it("adds champion pick bonus when pick matches league winner", () => {
+  const players: PlayersData[] = [
+    { id: "u1", username: "alice", email: "a@x.com", userBolaoId: "ub-1" },
+    { id: "u2", username: "bob", email: "b@x.com", userBolaoId: "ub-2" },
+  ]
+
+  const result = calcLead({
+    players,
+    fixtures: [],
+    bets: [],
+    championPicks: [
+      { user_bolao_id: "ub-1", team_id: 10, team_name: "Brazil", team_logo: "b.png" } as any,
+    ],
+    leagueWinnerTeamId: 10,
+  })
+
+  expect(result.find((r) => r.name === "alice")?.total).toBe(500)
+  expect(result.find((r) => r.name === "bob")?.total).toBe(0)
+})
+```
+
+- [ ] **Step 2: Run test — verify FAIL**
+
+- [ ] **Step 3: Extend `calcLead`**
+
+```typescript
+import { ChampionPick } from "./definitions"
+import { CHAMPION_PICK_BONUS_POINTS } from "./utils"
+
+export const calcLead = ({
+  players,
+  fixtures,
+  bets,
+  championPicks = [],
+  leagueWinnerTeamId = null,
+}: {
+  players: PlayersData[]
+  fixtures: FixtureData[]
+  bets: Bet[]
+  championPicks?: ChampionPick[]
+  leagueWinnerTeamId?: number | null
+}) => {
+  const picksByUserBolaoId = new Map(
+    championPicks.map((pick) => [pick.user_bolao_id, pick])
+  )
+
+  // ... existing loop ...
+  const pick = picksByUserBolaoId.get(player.userBolaoId)
+  const championBonus =
+    leagueWinnerTeamId !== null && pick?.team_id === leagueWinnerTeamId
+      ? CHAMPION_PICK_BONUS_POINTS
+      : 0
+
+  total = total + totalMatchDay + championBonus
+
+  lead.push({
+    name: player.username || getEmailUsername(player.email),
+    total,
+    championPick: pick
+      ? { id: pick.team_id, name: pick.team_name, logo: pick.team_logo }
+      : null,
+  })
+}
+```
+
+- [ ] **Step 4: Run tests — verify PASS**
+
+Run: `yarn test app/lib/__tests__/calcLeadFactory.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/calcLeadFactory.ts app/lib/__tests__/calcLeadFactory.test.ts
+git commit -m "feat: add champion pick bonus to leaderboard scoring"
+```
+
+---
+
+### Task 7: Controllers
+
+**Files:**
+- Modify: `app/lib/controllerBet.ts`
+- Modify: `app/lib/controllerLead.ts`
+- Modify: `app/lib/__tests__/controllerBet.test.ts`
+- Modify: `app/lib/__tests__/controllerLead.test.ts`
+
+- [ ] **Step 1: Extend `controllerBet.getData`**
+
+Fetch in parallel with existing data:
+- `allSeasonFixtures = await fetchFixtures({ leagueId, year })` *(no round)*
+- `userChampionPick = await fetchChampionPick(currentUserBolao.id)` *(logged-in user, NOT admin-selected player)*
+
+Return additional fields:
+
+```typescript
+championPickTeams: getTeamsFromFixtures(allSeasonFixtures),
+isChampionPickLocked: isChampionPickLocked(allSeasonFixtures),
+championPickLockDate: getChampionPickLockDate(allSeasonFixtures),
+userChampionPick,
+allSeasonFixtures, // needed by action lock check; optional to expose to page
+```
+
+- [ ] **Step 2: Extend `controllerLead.getData`**
+
+```typescript
+import { fetchChampionPicks, fetchLeague } from "./data"
+import { getLeagueWinnerTeamId } from "./championPick"
+import { isChampionPickLocked } from "./utils"
+
+// inside getData:
+const [fixtures, championPicks, league] = await Promise.all([
+  fetchFixtures({ leagueId, year }),
+  fetchChampionPicks(userBoloesIds),
+  fetchLeague(Number(leagueId)),
+])
+
+return {
+  bolao,
+  fixtures,
+  players,
+  bets,
+  championPicks,
+  isChampionPickLocked: isChampionPickLocked(fixtures),
+  leagueWinnerTeamId: getLeagueWinnerTeamId(league),
+}
+```
+
+- [ ] **Step 3: Update controller tests** — mock new fetchers; assert new return fields.
+
+- [ ] **Step 4: Run tests**
+
+Run: `yarn test app/lib/__tests__/controllerBet.test.ts app/lib/__tests__/controllerLead.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/lib/controllerBet.ts app/lib/controllerLead.ts app/lib/__tests__/controllerBet.test.ts app/lib/__tests__/controllerLead.test.ts
+git commit -m "feat: expose champion pick state in bet and lead controllers"
+```
+
+---
+
+### Task 8: i18n strings
+
+**Files:**
+- Modify: `messages/en.json`
+- Modify: `messages/pt-br.json`
+
+- [ ] **Step 1: Add `championPick` namespace to both files**
+
+`en.json`:
+
+```json
+"championPick": {
+  "label": "Championship winner",
+  "placeholder": "Select a team — optional",
+  "selectTeam": "Select championship winner",
+  "statusUnlockedNoPick": "Pick the team you think will win. +500 pts if correct. Others' picks hidden until the first game.",
+  "statusUnlockedHasPick": "You picked {team}. Change until {date}.",
+  "statusLocked": "Picks locked. See everyone's picks on the Lead page.",
+  "statusWon": "{team} won! +500 bonus points.",
+  "statusLost": "{team} won. Your pick didn't match.",
+  "leadColumnHeader": "Winner pick",
+  "leadColumnSubtitle": "+500 pts if correct",
+  "noPick": "—"
+}
+```
+
+`pt-br.json`:
+
+```json
+"championPick": {
+  "label": "Campeão do torneio",
+  "placeholder": "Selecione um time — opcional",
+  "selectTeam": "Selecionar campeão do torneio",
+  "statusUnlockedNoPick": "Escolha o time campeão. +500 pts se acertar. Palpites dos outros ficam ocultos até o primeiro jogo.",
+  "statusUnlockedHasPick": "Você escolheu {team}. Pode alterar até {date}.",
+  "statusLocked": "Palpites bloqueados. Veja todos no Ranking.",
+  "statusWon": "{team} venceu! +500 pontos bônus.",
+  "statusLost": "{team} venceu. Seu palpite não bateu.",
+  "leadColumnHeader": "Campeão",
+  "leadColumnSubtitle": "+500 pts se acertar",
+  "noPick": "—"
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add messages/en.json messages/pt-br.json
+git commit -m "feat: add champion pick i18n strings"
+```
+
+---
+
+### Task 9: ChampionPickSelector component (TDD)
+
+**Files:**
+- Create: `app/ui/bolao/bet/championPickSelector.tsx`
+- Create: `app/ui/bolao/bet/__tests__/championPickSelector.test.tsx`
+
+Mirror `playerSelector.tsx` structure exactly:
+
+```typescript
+"use client"
+
+import { useTranslations } from "next-intl"
+import { ChampionTeam, ChampionPick } from "@/app/lib/definitions"
+import { createOrUpdateChampionPick } from "@/app/lib/actions"
+import { formatDateFixtures } from "@/app/lib/utils"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+type Props = {
+  bolaoId: string
+  userBolaoId: string
+  teams: ChampionTeam[]
+  userChampionPick: ChampionPick | null
+  isLocked: boolean
+  lockDate: Date | null
+  leagueWinnerTeamId: number | null
+  locale: string
+}
+
+function ChampionPickSelector({ ... }: Props) {
+  const t = useTranslations("championPick")
+
+  const handleChange = async (teamIdStr: string) => {
+    const team = teams.find((t) => t.id === Number(teamIdStr))
+    if (!team) return
+    await createOrUpdateChampionPick({
+      userBolaoId,
+      bolaoId,
+      teamId: team.id,
+      teamName: team.name,
+      teamLogo: team.logo,
+    })
+  }
+
+  const statusLine = /* derive from isLocked, userChampionPick, leagueWinnerTeamId, lockDate */
+
+  if (teams.length === 0) return null
+
+  return (
+    <div className="mb-4 flex justify-center">
+      <div className="w-full max-w-xs">
+        <div className="mb-1 text-xs font-medium text-muted-foreground">
+          {t("label")}
+        </div>
+        <Select
+          value={userChampionPick ? String(userChampionPick.team_id) : undefined}
+          onValueChange={handleChange}
+          disabled={isLocked}
+        >
+          <SelectTrigger aria-label={t("selectTeam")}>
+            <SelectValue placeholder={t("placeholder")} />
+          </SelectTrigger>
+          <SelectContent>
+            {teams.map((team) => (
+              <SelectItem key={team.id} value={String(team.id)}>
+                {team.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="mt-1 text-xs text-muted-foreground">{statusLine}</p>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 1: Write component tests** — renders label, disabled when locked, hidden when no teams, calls action on change.
+- [ ] **Step 2: Implement component**
+- [ ] **Step 3: Run tests — PASS**
+
+Run: `yarn test app/ui/bolao/bet/__tests__/championPickSelector.test.tsx`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/ui/bolao/bet/championPickSelector.tsx app/ui/bolao/bet/__tests__/championPickSelector.test.tsx
+git commit -m "feat: add champion pick selector component"
+```
+
+---
+
+### Task 10: Bet page integration
+
+**Files:**
+- Modify: `app/bolao/[id]/bet/page.tsx`
+- Modify: `app/__tests__/bolao/[id]/bet/page.test.tsx` *(if exists)*
+
+- [ ] **Step 1: Render selector below admin PlayerSelector**
+
+```tsx
+import ChampionPickSelector from "@/app/ui/bolao/bet/championPickSelector"
+import { getLocale } from "next-intl/server"
+
+// inside BetPage, after PlayerSelector block:
+{data.championPickTeams.length > 0 && (
+  <ChampionPickSelector
+    bolaoId={params.id}
+    userBolaoId={data.currentUserBolao.id}
+    teams={data.championPickTeams}
+    userChampionPick={data.userChampionPick}
+    isLocked={data.isChampionPickLocked}
+    lockDate={data.championPickLockDate}
+    leagueWinnerTeamId={null}
+    locale={await getLocale()}
+  />
+)}
+```
+
+Note: `userBolaoId` uses `currentUserBolao` (logged-in user), not admin-selected `userBolao`.
+
+- [ ] **Step 2: Run tests + dev smoke test**
+
+Run: `yarn test app/__tests__/bolao/[id]/bet/page.test.tsx`
+Run: `yarn dev` → open `/bolao/{id}/bet` → verify two selects stack for admin, one for regular user.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/bolao/[id]/bet/page.tsx
+git commit -m "feat: add champion pick selector to bet page"
+```
+
+---
+
+### Task 11: Lead page column (TDD)
+
+**Files:**
+- Modify: `app/ui/bolao/lead/tableLead.tsx`
+- Modify: `app/bolao/[id]/lead/page.tsx`
+- Modify: `app/ui/bolao/lead/__tests__/tableLead.test.tsx`
+
+- [ ] **Step 1: Write failing test — column hidden before lock, shown after**
+
+```typescript
+it("shows winner pick column when locked", async () => {
+  render(
+    await TableLead({
+      data: [{ name: "alice", total: 100, championPick: { id: 10, name: "Brazil", logo: "b.png" } }],
+      isChampionPickLocked: true,
+    })
+  )
+  expect(screen.getByText("Winner pick")).toBeInTheDocument()
+  expect(screen.getByText("Brazil")).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Extend `TableLead` props and render column**
+
+Add optional `isChampionPickLocked: boolean`. When true, insert column between player name and score showing team name (or `t("noPick")`).
+
+- [ ] **Step 3: Update `lead/page.tsx`**
+
+```typescript
+const sortedLead = [...calcLead({
+  players: data.players,
+  fixtures: data.fixtures,
+  bets: data.bets,
+  championPicks: data.championPicks,
+  leagueWinnerTeamId: data.leagueWinnerTeamId,
+})].sort((a, b) => b.total - a.total)
+
+<TableLead data={sortedLead} isChampionPickLocked={data.isChampionPickLocked} />
+```
+
+- [ ] **Step 4: Run tests — PASS**
+
+Run: `yarn test app/ui/bolao/lead/__tests__/tableLead.test.tsx app/__tests__/bolao/[id]/lead/page.test.tsx`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/ui/bolao/lead/tableLead.tsx app/bolao/[id]/lead/page.tsx app/ui/bolao/lead/__tests__/tableLead.test.tsx
+git commit -m "feat: show champion picks on lead page after lock"
+```
+
+---
+
+### Task 12: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `yarn test`
+Expected: all pass
+
+- [ ] **Step 2: Run lint**
+
+Run: `yarn lint`
+Expected: no errors
+
+- [ ] **Step 3: Run production build**
+
+Run: `yarn build`
+Expected: success
+
+- [ ] **Step 4: Manual smoke test checklist**
+
+1. Open bet page before first game → champion Select visible, editable
+2. Pick a team → persists on refresh
+3. Change pick → updates
+4. Admin sees two stacked selects (Betting as + Champion winner)
+5. After earliest kickoff (mock with fake timers or past fixture data) → Select disabled
+6. Lead page before lock → no Winner pick column
+7. Lead page after lock → column shows each player's team or "—"
+8. When league API has winner → correct pick adds 500 to score total
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| `champion_picks` table | Task 3 |
+| Upsert server action with auth + lock | Task 5 |
+| Lock at earliest kickoff | Task 2 |
+| Teams from fixtures | Task 2 |
+| PlayerSelector-style UI on Bet page | Tasks 9–10 |
+| Two stacked selects (admin + champion) | Task 10 |
+| Lead column after lock | Task 11 |
+| +500 bonus at season end | Tasks 1, 6 |
+| League API winner resolution | Tasks 2, 7 |
+| i18n explanation copy | Task 8 |
+| Optional pick, no penalty | Tasks 5, 9 (no required validation) |
+| Hidden before lock on Lead | Task 11 |
+| Admin pick uses logged-in user | Task 10 (`currentUserBolao`) |
+| Edge: no fixtures → hide | Task 9 (`teams.length === 0`) |
+
+## Out of scope (do not implement)
+
+- Dedicated nav tab
+- Dismissible banner
+- Pick history
+- Admin winner override
+- "+500" badge on score column

--- a/docs/superpowers/specs/2026-06-07-championship-winner-pick-design.md
+++ b/docs/superpowers/specs/2026-06-07-championship-winner-pick-design.md
@@ -1,0 +1,219 @@
+# Championship Winner Pick — Design Spec
+
+**Date:** 2026-06-07  
+**Branch:** `feature/championship-winner-pick`  
+**Status:** Approved (brainstorming)
+
+## Summary
+
+Each member of a bolão (group) may optionally pick one team they believe will win the championship. Picks can be changed freely until the scheduled kickoff of the earliest fixture in the season. Other members' picks remain hidden until that lock moment, then are revealed on the Bet page and Lead page. Correct picks earn **500 bonus points** added to the leaderboard total once the official championship winner is known via the League API.
+
+## Requirements (decided)
+
+| Decision | Choice |
+|----------|--------|
+| Scoring | +500 bonus points for correct pick (configurable constant) |
+| Change before lock | Yes — update freely until lock |
+| Visibility before lock | Hidden — only your own pick visible to you |
+| Visibility after lock | Revealed — all picks visible on Bet page and Lead page |
+| Required? | Optional — no penalty for skipping |
+| UI location (v1) | Section on existing Bet page; revealed picks also on Lead page |
+| Lock trigger | Scheduled kickoff of earliest season fixture (even if status is still `NS`) |
+| Bonus awarded | Only when official winner is known at season end |
+| Team list source | Unique teams derived from all season fixtures |
+| Winner resolution | League API `winner` field on current season (handles leagues and knockouts) |
+
+## Architecture
+
+### Approach
+
+Dedicated `champion_picks` table (Approach 1). Keeps champion picks separate from match bets, enforces one pick per user per bolão, and avoids overloading the `bets` table or `user_bolao` membership row.
+
+### Data model
+
+**New table: `champion_picks`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID PK | auto-generated via `uuid_generate_v4()` |
+| `user_bolao_id` | VARCHAR | references `user_bolao.id`, **UNIQUE** |
+| `team_id` | INTEGER | api-football team ID |
+| `team_name` | VARCHAR | denormalized for display |
+| `team_logo` | VARCHAR | denormalized logo URL |
+| `created_at` | TIMESTAMP | first save |
+| `updated_at` | TIMESTAMP | last change |
+
+**Migration:** add to `scripts/seed.js` (and any production migration path used by the project).
+
+**New constant:** `CHAMPION_PICK_BONUS_POINTS = 500` in `app/lib/utils.ts`.
+
+**New types** in `app/lib/definitions.ts`:
+
+- `ChampionPick` — row shape
+- `ChampionPickResult` — server action result (success | error)
+- Extend `LeadData` with optional `championPick?: { teamId: number; teamName: string; teamLogo: string }`
+
+### Server actions (`app/lib/actions.ts`)
+
+- `createOrUpdateChampionPick({ userBolaoId, teamId, teamName, teamLogo })`
+  - Authenticate via `auth()`
+  - Verify caller owns the `user_bolao_id`
+  - Reject if champion pick is locked (server-side enforcement)
+  - Upsert into `champion_picks`
+
+### Data fetchers (`app/lib/data.ts`)
+
+- `fetchChampionPick(userBolaoId: string)` — single pick
+- `fetchChampionPicks(userBolaoIds: string[])` — all picks for a bolao
+
+### Utilities (`app/lib/utils.ts`)
+
+- `isChampionPickLocked(fixtures: FixtureData[]): boolean` — `Date.now() >= earliest fixture kickoff`
+- `getChampionPickLockDate(fixtures: FixtureData[]): Date | null` — for status messages
+- `getTeamsFromFixtures(fixtures: FixtureData[]): Team[]` — dedupe home/away by `team.id`, sort alphabetically by name
+
+## Lock logic & visibility
+
+```
+earliestKickoff = sortFixtures(allSeasonFixtures)[0].fixture.date
+isLocked = now >= earliestKickoff
+```
+
+| State | Own pick (Bet page) | Others' picks (Bet page) | Lead page column |
+|-------|---------------------|--------------------------|------------------|
+| Before lock | Visible + editable | Hidden | Column hidden |
+| After lock, no winner yet | Visible, read-only | Revealed | Column shown |
+| After winner known | Visible, read-only | Revealed | Column shown; bonus in score |
+
+**Server-side enforcement:** lock check in `createOrUpdateChampionPick` — UI disable alone is insufficient.
+
+## UI
+
+### Bet page — `ChampionPickSection`
+
+New component rendered in the **same slot as the admin "Betting as" selector** — centered above `TableMatchDayBets`, between `Pagination` and the match cards. Reuses the `PlayerSelector` layout pattern (not a separate card or team grid).
+
+**Layout (matches `PlayerSelector`):**
+
+```
+<div className="mb-4 flex justify-center">
+  <div className="w-full max-w-xs">
+    <div className="mb-1 text-xs font-medium text-muted-foreground">{label}</div>
+    <Select … />
+    <p className="mt-1 text-xs text-muted-foreground">{statusLine}</p>
+  </div>
+</div>
+```
+
+- **Label:** e.g. "Championship winner" (i18n)
+- **Select:** Shadcn `Select` with one option per team (team name in trigger; optional small crest in `SelectItem`)
+- **Status line:** contextual helper text below the dropdown (rules summary when unlocked; lock/winner message when locked)
+
+**When unlocked (all members, not admin-only):**
+
+- Dropdown enabled; selecting a team saves immediately via `createOrUpdateChampionPick`
+- Placeholder: "Select a team — optional"
+- Current pick shown as selected value; user can change freely until lock
+
+**When locked:**
+
+- Dropdown disabled/read-only, showing the user's pick
+- Status line: picks are locked; others' picks visible on Lead page
+- No inline list of all members' picks on Bet page in v1 — Lead page is the group reveal surface
+
+**When no season fixtures exist:** hide section entirely.
+
+**Admin coexistence:** two stacked selects in the same area is intentional and accepted — admin `PlayerSelector` first (admin only), champion pick `Select` below (all members).
+
+**Controller:** extend `controllerBet.getData` to return `{ championPicks, isChampionPickLocked, lockDate, teams, userChampionPick }`.
+
+### Lead page — revealed picks column
+
+Extend `TableLead` with a **"Winner pick"** column when `isChampionPickLocked === true`.
+
+- Each row: team crest + name, or "—" if no pick
+- Column header subtitle explains +500 pts bonus (i18n)
+- Score column includes match-bet points + champion bonus when winner is known (no separate "+500" badge in v1 — bonus is silent in the total)
+
+**Controller:** extend `controllerLead.getData` to fetch champion picks, lock state, and league winner.
+
+### User-facing explanation (i18n)
+
+Add `championPick` namespace to `messages/en.json` and `messages/pt-br.json`.
+
+**Bet page selector (compact, below dropdown):**
+
+- **Label:** "Championship winner"
+- **Placeholder:** "Select a team — optional"
+- **Contextual status lines (small muted text under Select):**
+  - Unlocked, no pick: "Pick the team you think will win. +500 pts if correct. Others' picks hidden until the first game."
+  - Unlocked, has pick: "You picked {team}. Change until {date}."
+  - Locked, pre-winner: "Picks locked. See everyone's picks on the Lead page."
+  - Season ended, correct: "{team} won! +500 bonus points."
+  - Season ended, incorrect: "{team} won. Your pick didn't match."
+
+**Lead page:**
+
+- Column header: "Winner pick"
+- Subtitle: "Bonus pick made before the championship started (+500 pts if correct)."
+
+Portuguese equivalents in `pt-br.json`.
+
+No separate help page or dismissible banner in v1.
+
+## Scoring
+
+Extend `calcLead` in `app/lib/calcLeadFactory.ts`:
+
+```typescript
+total = matchBetPoints + (pick?.teamId === leagueWinnerTeamId ? CHAMPION_PICK_BONUS_POINTS : 0)
+```
+
+**Winner resolution:** `fetchLeague(bolao.competition_id)` → current season → read official `winner` team ID. Award bonus only when winner is non-null.
+
+**Before winner known:** bonus = 0 for all players; picks visible after lock but do not affect score yet.
+
+## Error handling & edge cases
+
+| Case | Behavior |
+|------|----------|
+| No fixtures yet | Hide champion pick section |
+| User joins after lock | See others' picks; cannot create own pick |
+| User never picked | Show "—"; no penalty |
+| API winner unavailable at season end | No bonus awarded; log warning; picks remain visible |
+| Admin "betting as" another player | Champion pick always tied to logged-in user's `user_bolao_id` (admin override applies to match bets only) |
+
+## Testing
+
+- **Unit:** `isChampionPickLocked`, `getChampionPickLockDate`, `getTeamsFromFixtures`, `calcLead` with champion bonus
+- **Actions:** reject upsert when locked; allow when unlocked; auth ownership check
+- **Components:** `ChampionPickSection` — editable vs read-only; Lead column hidden before lock, shown after
+- **Controllers:** extend existing `controllerBet` and `controllerLead` test coverage
+
+## Out of scope (v1)
+
+- Dedicated nav tab for champion picks
+- Dismissible first-visit banner / onboarding
+- Pick history / audit trail
+- Admin manual winner override
+- Separate "+500" badge on Lead page score column
+- Per-bolão configurable bonus points (global constant only)
+
+## Files to create or modify (implementation reference)
+
+| File | Change |
+|------|--------|
+| `scripts/seed.js` | Add `champion_picks` table |
+| `app/lib/definitions.ts` | New types |
+| `app/lib/utils.ts` | Constants + lock/team helpers |
+| `app/lib/data.ts` | Fetch champion picks |
+| `app/lib/actions.ts` | `createOrUpdateChampionPick` |
+| `app/lib/calcLeadFactory.ts` | Champion bonus in scoring |
+| `app/lib/controllerBet.ts` | Return champion pick data |
+| `app/lib/controllerLead.ts` | Return champion picks + winner |
+| `app/ui/bolao/bet/championPickSection.tsx` | New component |
+| `app/bolao/[id]/bet/page.tsx` | Render section |
+| `app/ui/bolao/lead/tableLead.tsx` | Winner pick column |
+| `app/bolao/[id]/lead/page.tsx` | Pass new props |
+| `messages/en.json`, `messages/pt-br.json` | i18n strings |
+| Tests | As listed above |

--- a/messages/en.json
+++ b/messages/en.json
@@ -115,7 +115,8 @@
     "bettingAs": "Betting as",
     "selectPlayer": "Select player",
     "selectPlayerToBetAs": "Select player to bet as",
-    "loading": "loading..."
+    "loading": "loading...",
+    "errorLoadFailed": "Could not load the bet page. Check your connection and try again."
   },
   "resultsPage": {
     "nextGames": "Next games",
@@ -137,5 +138,21 @@
     "player": "player",
     "score": "score",
     "needs": "needs"
+  },
+  "championPick": {
+    "label": "Winner (+500 pts)",
+    "placeholder": "Select a team — optional",
+    "selectTeam": "Select championship winner",
+    "statusUnlockedNoPick": "Pick the team you think will win. +500 pts if correct. Others' picks hidden until the first game.",
+    "statusUnlockedHasPick": "You picked {team}. Change until {date}.",
+    "statusLocked": "Picks locked. See everyone's picks on the Lead page.",
+    "statusWon": "{team} won! +500 bonus points.",
+    "statusLost": "{team} won. Your pick didn't match.",
+    "leadColumnHeader": "Winner pick",
+    "noPick": "—",
+    "saveSuccessTitle": "Pick saved",
+    "saveSuccessDescription": "{team} is your championship winner pick.",
+    "saveErrorTitle": "Could not save pick",
+    "saveErrorDescription": "Something went wrong while saving your pick. Please try again."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -140,7 +140,7 @@
     "needs": "needs"
   },
   "championPick": {
-    "label": "Winner (+500 pts)",
+    "label": "Winner (+500 pts) — beta",
     "placeholder": "Select a team — optional",
     "selectTeam": "Select championship winner",
     "statusUnlockedNoPick": "Pick the team you think will win. +500 pts if correct. Others' picks hidden until the first game.",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -140,7 +140,7 @@
     "needs": "faltam"
   },
   "championPick": {
-    "label": "Campeão (+500 pts)",
+    "label": "Campeão (+500 pts) — beta",
     "placeholder": "Selecione um time — opcional",
     "selectTeam": "Selecionar campeão do torneio",
     "statusUnlockedNoPick": "Escolha o time campeão. +500 pts se acertar. Palpites dos outros ficam ocultos até o primeiro jogo.",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -115,7 +115,8 @@
     "bettingAs": "Apostando como",
     "selectPlayer": "Selecionar jogador",
     "selectPlayerToBetAs": "Selecionar jogador para apostar como",
-    "loading": "carregando..."
+    "loading": "carregando...",
+    "errorLoadFailed": "Não foi possível carregar a página de apostas. Verifique sua conexão e tente novamente."
   },
   "resultsPage": {
     "nextGames": "Próximos jogos",
@@ -137,5 +138,21 @@
     "player": "jogador",
     "score": "pontos",
     "needs": "faltam"
+  },
+  "championPick": {
+    "label": "Campeão (+500 pts)",
+    "placeholder": "Selecione um time — opcional",
+    "selectTeam": "Selecionar campeão do torneio",
+    "statusUnlockedNoPick": "Escolha o time campeão. +500 pts se acertar. Palpites dos outros ficam ocultos até o primeiro jogo.",
+    "statusUnlockedHasPick": "Você escolheu {team}. Pode alterar até {date}.",
+    "statusLocked": "Palpites bloqueados. Veja todos no Ranking.",
+    "statusWon": "{team} venceu! +500 pontos bônus.",
+    "statusLost": "{team} venceu. Seu palpite não bateu.",
+    "leadColumnHeader": "Campeão",
+    "noPick": "—",
+    "saveSuccessTitle": "Palpite salvo",
+    "saveSuccessDescription": "{team} é seu palpite de campeão.",
+    "saveErrorTitle": "Não foi possível salvar",
+    "saveErrorDescription": "Algo deu errado ao salvar seu palpite. Tente novamente."
   }
 }

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -97,6 +97,31 @@ async function seedBets(client) {
   }
 }
 
+async function seedChampionPicks(client) {
+  try {
+    const createTable = await client.sql`
+      CREATE TABLE IF NOT EXISTS champion_picks (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        user_bolao_id VARCHAR(100) NOT NULL UNIQUE,
+        team_id INTEGER NOT NULL,
+        team_name VARCHAR(200) NOT NULL,
+        team_logo VARCHAR(500) NOT NULL,
+        created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+        updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+    `
+
+    console.log(`Created "champion_picks" table`)
+
+    return {
+      createTable,
+    }
+  } catch (error) {
+    console.error("Error creating table champion_picks:", error)
+    throw error
+  }
+}
+
 async function main() {
   const client = await db.connect()
 
@@ -104,6 +129,7 @@ async function main() {
   await seedBoloes(client)
   await seedUserBolao(client)
   await seedBets(client)
+  await seedChampionPicks(client)
 
   await client.end()
 }


### PR DESCRIPTION
## Summary
- Add optional championship winner pick on the Bet page (editable until the first fixture kickoff, hidden after lock)
- Show a Winner pick column on the Lead page (hyphens before lock, team names after lock)
- Award +500 bonus points in leaderboard scoring when the League API reports the official winner
- Enforce pick lock server-side in `createOrUpdateChampionPick` and strip pick names from Lead payload before lock

## Test plan
- [x] Run `yarn seed` against the target database to create `champion_picks` table
- [x] Pick a winner on Bet page before lock — confirm green success toast
- [x] Confirm selector disappears after first kickoff
- [x] Confirm Lead page shows `—` before lock and team names after lock
- [x] Confirm admin "Betting as" selector still works (Clerk `privateMetadata.role`)
- [ ] After tournament ends (API winner set), confirm +500 added to correct player's Lead total
- [x] `yarn test` (878 passing)


Made with [Cursor](https://cursor.com)