### PR TITLE
fix(lead): resolve champion winner from final fixture or standings

### DIFF
--- a/app/lib/__tests__/championPick.test.ts
+++ b/app/lib/__tests__/championPick.test.ts
@@ -1,25 +1,56 @@
-import { describe, it, expect, vi, afterEach } from "vitest"
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
 import {
   isChampionPickLocked,
   getChampionPickLockDate,
   getTeamsFromFixtures,
 } from "../utils"
-import { getLeagueWinnerTeamId } from "../championPick"
-import type { FixtureData } from "../definitions"
+import {
+  isSeasonFinished,
+  getCupWinnerTeamId,
+  getLeagueWinnerFromStandings,
+  resolveChampionTeamId,
+} from "../championPick"
+import type { FixtureData, Standing } from "../definitions"
+
+vi.mock("../data", () => ({
+  fetchStandings: vi.fn(),
+}))
 
 function makeFixture(
   id: number,
   date: string,
-  home: { id: number; name: string },
-  away: { id: number; name: string }
+  home: { id: number; name: string; winner?: boolean | null },
+  away: { id: number; name: string; winner?: boolean | null },
+  statusShort: string = "NS"
 ): FixtureData {
   return {
-    fixture: { id, date: new Date(date) } as FixtureData["fixture"],
+    fixture: {
+      id,
+      date: new Date(date),
+      status: { long: "", short: statusShort, elapsed: null },
+    } as unknown as FixtureData["fixture"],
     teams: {
-      home: { ...home, logo: `${home.name}.png`, winner: null },
-      away: { ...away, logo: `${away.name}.png`, winner: null },
+      home: {
+        id: home.id,
+        name: home.name,
+        logo: `${home.name}.png`,
+        winner: home.winner ?? null,
+      },
+      away: {
+        id: away.id,
+        name: away.name,
+        logo: `${away.name}.png`,
+        winner: away.winner ?? null,
+      },
     },
   } as FixtureData
+}
+
+function makeStanding(rank: number, teamId: number, teamName: string): Standing {
+  return {
+    rank,
+    team: { id: teamId, name: teamName, logo: `${teamName}.png` },
+  } as Standing
 }
 
 describe("champion pick utils", () => {
@@ -106,22 +137,225 @@ describe("champion pick utils", () => {
       ])
     })
   })
+})
 
-  describe("getLeagueWinnerTeamId", () => {
-    it("returns winner id from current season", () => {
-      const league = {
-        seasons: [
-          { year: 2026, current: true, winner: { id: 10, name: "Brazil" } },
-        ],
-      }
-      expect(getLeagueWinnerTeamId(league)).toBe(10)
+describe("winner resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("isSeasonFinished", () => {
+    it("returns false for empty fixtures", () => {
+      expect(isSeasonFinished([])).toBe(false)
     })
 
-    it("returns null when no winner yet", () => {
-      const league = {
-        seasons: [{ year: 2026, current: true, winner: null }],
-      }
-      expect(getLeagueWinnerTeamId(league)).toBeNull()
+    it("returns false when a fixture is still open to play", () => {
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "FT"),
+        makeFixture(2, "2026-06-15T19:00:00Z", { id: 3, name: "C" }, { id: 4, name: "D" }, "NS"),
+      ]
+      expect(isSeasonFinished(fixtures)).toBe(false)
+    })
+
+    it("returns false when a fixture is in play", () => {
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "2H"),
+      ]
+      expect(isSeasonFinished(fixtures)).toBe(false)
+    })
+
+    it("returns true when all fixtures are finished", () => {
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "FT"),
+        makeFixture(2, "2026-06-15T19:00:00Z", { id: 3, name: "C" }, { id: 4, name: "D" }, "PEN"),
+      ]
+      expect(isSeasonFinished(fixtures)).toBe(true)
+    })
+  })
+
+  describe("getCupWinnerTeamId", () => {
+    it("returns the winning team of the chronologically last fixture", () => {
+      const fixtures = [
+        makeFixture(
+          2,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: true },
+          { id: 2, name: "France", winner: false },
+          "PEN"
+        ),
+        makeFixture(
+          1,
+          "2022-12-17T15:00:00Z",
+          { id: 7, name: "Croatia", winner: true },
+          { id: 31, name: "Morocco", winner: false },
+          "FT"
+        ),
+      ]
+      expect(getCupWinnerTeamId(fixtures)).toBe(26)
+    })
+
+    it("returns the away team when it won the final", () => {
+      const fixtures = [
+        makeFixture(
+          1,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: false },
+          { id: 2, name: "France", winner: true },
+          "FT"
+        ),
+      ]
+      expect(getCupWinnerTeamId(fixtures)).toBe(2)
+    })
+
+    it("returns null when the last fixture has no winner flag", () => {
+      const fixtures = [
+        makeFixture(
+          1,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina" },
+          { id: 2, name: "France" },
+          "NS"
+        ),
+      ]
+      expect(getCupWinnerTeamId(fixtures)).toBeNull()
+    })
+
+    it("returns null for empty fixtures", () => {
+      expect(getCupWinnerTeamId([])).toBeNull()
+    })
+
+    it("does not mutate the input fixtures order", () => {
+      const fixtures = [
+        makeFixture(
+          2,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: true },
+          { id: 2, name: "France", winner: false },
+          "PEN"
+        ),
+        makeFixture(
+          1,
+          "2022-12-17T15:00:00Z",
+          { id: 7, name: "Croatia", winner: true },
+          { id: 31, name: "Morocco", winner: false },
+          "FT"
+        ),
+      ]
+      getCupWinnerTeamId(fixtures)
+      expect(fixtures[0].fixture.id).toBe(2)
+    })
+  })
+
+  describe("getLeagueWinnerFromStandings", () => {
+    it("returns the rank 1 team of the first group", () => {
+      const standings: Standing[][] = [
+        [
+          makeStanding(2, 40, "Marseille"),
+          makeStanding(1, 85, "PSG"),
+          makeStanding(3, 80, "Lyon"),
+        ],
+      ]
+      expect(getLeagueWinnerFromStandings(standings)).toBe(85)
+    })
+
+    it("returns null for empty standings", () => {
+      expect(getLeagueWinnerFromStandings([])).toBeNull()
+    })
+
+    it("returns null when no rank 1 entry exists", () => {
+      const standings: Standing[][] = [[makeStanding(2, 40, "Marseille")]]
+      expect(getLeagueWinnerFromStandings(standings)).toBeNull()
+    })
+  })
+
+  describe("resolveChampionTeamId", () => {
+    it("returns null while the season is in progress and does not fetch standings", async () => {
+      const { fetchStandings } = await import("../data")
+      const fixtures = [
+        makeFixture(1, "2026-06-11T19:00:00Z", { id: 1, name: "A" }, { id: 2, name: "B" }, "NS"),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "League",
+        leagueId: "61",
+        year: 2026,
+        fixtures,
+      })
+
+      expect(result).toBeNull()
+      expect(fetchStandings).not.toHaveBeenCalled()
+    })
+
+    it("resolves a cup winner from the final fixture without fetching standings", async () => {
+      const { fetchStandings } = await import("../data")
+      const fixtures = [
+        makeFixture(
+          1,
+          "2022-12-18T15:00:00Z",
+          { id: 26, name: "Argentina", winner: true },
+          { id: 2, name: "France", winner: false },
+          "PEN"
+        ),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "Cup",
+        leagueId: "1",
+        year: 2022,
+        fixtures,
+      })
+
+      expect(result).toBe(26)
+      expect(fetchStandings).not.toHaveBeenCalled()
+    })
+
+    it("resolves a league winner from standings when the season is finished", async () => {
+      const { fetchStandings } = await import("../data")
+      vi.mocked(fetchStandings).mockResolvedValue({
+        standings: [[makeStanding(1, 85, "PSG"), makeStanding(2, 40, "Marseille")]],
+      } as any)
+
+      const fixtures = [
+        makeFixture(1, "2026-05-20T19:00:00Z", { id: 85, name: "PSG" }, { id: 40, name: "Marseille" }, "FT"),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "League",
+        leagueId: "61",
+        year: 2025,
+        fixtures,
+      })
+
+      expect(result).toBe(85)
+      expect(fetchStandings).toHaveBeenCalledWith({ leagueId: "61", year: 2025 })
+    })
+
+    it("returns null when standings are unavailable", async () => {
+      const { fetchStandings } = await import("../data")
+      vi.mocked(fetchStandings).mockResolvedValue([] as any)
+
+      const fixtures = [
+        makeFixture(1, "2026-05-20T19:00:00Z", { id: 85, name: "PSG" }, { id: 40, name: "Marseille" }, "FT"),
+      ]
+
+      const result = await resolveChampionTeamId({
+        leagueType: "League",
+        leagueId: "61",
+        year: 2025,
+        fixtures,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it("returns null for empty fixtures", async () => {
+      const result = await resolveChampionTeamId({
+        leagueType: "Cup",
+        leagueId: "1",
+        year: 2022,
+        fixtures: [],
+      })
+      expect(result).toBeNull()
     })
   })
 })

--- a/app/lib/__tests__/controllerLead.test.ts
+++ b/app/lib/__tests__/controllerLead.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/app/lib/data", () => ({
   fetchUsersBets: vi.fn(),
   fetchChampionPicks: vi.fn(),
   fetchLeague: vi.fn(),
+  fetchStandings: vi.fn(),
 }))
 
 // Mock Clerk client
@@ -92,11 +93,15 @@ describe("controllerLead", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    const { fetchChampionPicks, fetchLeague } = await import("@/app/lib/data")
+    const { fetchChampionPicks, fetchLeague, fetchStandings } = await import(
+      "@/app/lib/data"
+    )
     vi.mocked(fetchChampionPicks).mockResolvedValue([])
     vi.mocked(fetchLeague).mockResolvedValue({
-      seasons: [{ year: 2024, current: true, winner: null }],
+      league: { id: 2, name: "Champions League", type: "Cup" },
+      seasons: [{ year: 2024, current: true }],
     } as any)
+    vi.mocked(fetchStandings).mockResolvedValue([] as any)
   })
 
   describe("getData", () => {
@@ -305,6 +310,120 @@ describe("controllerLead", () => {
       const result = await getData({ bolaoId: "bolao-1" })
 
       expect(result.fixtures).toHaveLength(3)
+    })
+
+    it("should resolve a cup winner from the final fixture", async () => {
+      const { fetchBolao, fetchUsersBolao, fetchFixtures, fetchUsersBets } =
+        await import("@/app/lib/data")
+      const { clerkClient } = await import("@clerk/nextjs/server")
+
+      const mockClient = {
+        users: {
+          getUserList: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      }
+
+      const finalFixture: FixtureData = {
+        ...mockFixture,
+        fixture: {
+          ...mockFixture.fixture,
+          id: 2,
+          date: new Date("2024-06-01"),
+          status: { long: "Match Finished", short: "PEN", elapsed: 120 },
+        },
+        teams: {
+          home: { id: 26, name: "Argentina", logo: "arg.png", winner: true },
+          away: { id: 2, name: "France", logo: "fra.png", winner: false },
+        },
+      }
+
+      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
+      vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
+      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture, finalFixture])
+      vi.mocked(fetchUsersBets).mockResolvedValue([])
+      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+
+      const result = await getData({ bolaoId: "bolao-1" })
+
+      expect(result.leagueWinnerTeamId).toBe(26)
+    })
+
+    it("should resolve a league winner from standings when the season is finished", async () => {
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchLeague,
+        fetchStandings,
+      } = await import("@/app/lib/data")
+      const { clerkClient } = await import("@clerk/nextjs/server")
+
+      const mockClient = {
+        users: {
+          getUserList: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      }
+
+      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
+      vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
+      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture])
+      vi.mocked(fetchUsersBets).mockResolvedValue([])
+      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+      vi.mocked(fetchLeague).mockResolvedValue({
+        league: { id: 61, name: "Ligue 1", type: "League" },
+        seasons: [{ year: 2024, current: true }],
+      } as any)
+      vi.mocked(fetchStandings).mockResolvedValue({
+        standings: [
+          [
+            { rank: 1, team: { id: 85, name: "PSG", logo: "psg.png" } },
+            { rank: 2, team: { id: 80, name: "Lyon", logo: "lyon.png" } },
+          ],
+        ],
+      } as any)
+
+      const result = await getData({ bolaoId: "bolao-1" })
+
+      expect(result.leagueWinnerTeamId).toBe(85)
+      expect(fetchStandings).toHaveBeenCalledWith({ leagueId: "2", year: 2024 })
+    })
+
+    it("should return null winner while the season is in progress without fetching standings", async () => {
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchFixtures,
+        fetchUsersBets,
+        fetchStandings,
+      } = await import("@/app/lib/data")
+      const { clerkClient } = await import("@clerk/nextjs/server")
+
+      const mockClient = {
+        users: {
+          getUserList: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      }
+
+      const upcomingFixture: FixtureData = {
+        ...mockFixture,
+        fixture: {
+          ...mockFixture.fixture,
+          id: 3,
+          status: { long: "Not Started", short: "NS", elapsed: null as any },
+        },
+      }
+
+      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
+      vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
+      vi.mocked(fetchFixtures).mockResolvedValue([mockFixture, upcomingFixture])
+      vi.mocked(fetchUsersBets).mockResolvedValue([])
+      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+
+      const result = await getData({ bolaoId: "bolao-1" })
+
+      expect(result.leagueWinnerTeamId).toBeNull()
+      expect(fetchStandings).not.toHaveBeenCalled()
     })
 
     it("should propagate errors from fetchBolao", async () => {

--- a/app/lib/championPick.ts
+++ b/app/lib/championPick.ts
@@ -1,14 +1,67 @@
-type LeagueSeason = {
+import { FixtureData, Standing } from "./definitions"
+import { fetchStandings } from "./data"
+import {
+  sortFixtures,
+  STATUSES_OPEN_TO_PLAY,
+  STATUSES_IN_PLAY,
+} from "./utils"
+
+export function isSeasonFinished(fixtures: FixtureData[]): boolean {
+  if (fixtures.length === 0) return false
+
+  return fixtures.every(
+    (fixture) =>
+      !STATUSES_OPEN_TO_PLAY.includes(fixture.fixture.status.short) &&
+      !STATUSES_IN_PLAY.includes(fixture.fixture.status.short)
+  )
+}
+
+// Cup-style competitions (World Cup, Champions League...) are decided by the
+// chronologically last fixture: the API flags its winner even after penalties.
+export function getCupWinnerTeamId(fixtures: FixtureData[]): number | null {
+  if (fixtures.length === 0) return null
+
+  const sorted = sortFixtures([...fixtures])
+  const finalFixture = sorted[sorted.length - 1]
+
+  if (finalFixture.teams.home.winner === true) return finalFixture.teams.home.id
+  if (finalFixture.teams.away.winner === true) return finalFixture.teams.away.id
+
+  return null
+}
+
+export function getLeagueWinnerFromStandings(
+  standings: Standing[][]
+): number | null {
+  const firstGroup = standings[0]
+  if (!firstGroup) return null
+
+  const leader = firstGroup.find((standing) => standing.rank === 1)
+  return leader?.team.id ?? null
+}
+
+export async function resolveChampionTeamId({
+  leagueType,
+  leagueId,
+  year,
+  fixtures,
+}: {
+  leagueType: string | undefined
+  leagueId: string
   year: number
-  current: boolean
-  winner?: { id: number; name: string } | null
-}
+  fixtures: FixtureData[]
+}): Promise<number | null> {
+  if (!isSeasonFinished(fixtures)) return null
 
-type LeagueResponse = {
-  seasons: LeagueSeason[]
-}
+  if (leagueType === "Cup") {
+    return getCupWinnerTeamId(fixtures)
+  }
 
-export function getLeagueWinnerTeamId(league: LeagueResponse): number | null {
-  const currentSeason = league.seasons.find((season) => season.current)
-  return currentSeason?.winner?.id ?? null
+  // Points-based leagues (Premier League, Ligue 1...): rank 1 of the final standings.
+  const standingsLeague = await fetchStandings({ leagueId, year })
+  const standings: Standing[][] | undefined = standingsLeague?.standings
+
+  if (!Array.isArray(standings)) return null
+
+  return getLeagueWinnerFromStandings(standings)
 }

--- a/app/lib/controllerLead.ts
+++ b/app/lib/controllerLead.ts
@@ -8,7 +8,7 @@ import {
 } from "@/app/lib/data"
 import { FixtureData, UserBolao, Bet } from "./definitions"
 import { getPlayersFromUsersBolao } from "./players"
-import { getLeagueWinnerTeamId } from "./championPick"
+import { resolveChampionTeamId } from "./championPick"
 import { isChampionPickLocked } from "./utils"
 
 export async function getData({ bolaoId }: { bolaoId: string }) {
@@ -31,6 +31,13 @@ export async function getData({ bolaoId }: { bolaoId: string }) {
     fetchLeague(Number(leagueId)),
   ])
 
+  const leagueWinnerTeamId = await resolveChampionTeamId({
+    leagueType: league?.league?.type,
+    leagueId,
+    year,
+    fixtures,
+  })
+
   return {
     bolao,
     fixtures: fixtures as FixtureData[],
@@ -38,6 +45,6 @@ export async function getData({ bolaoId }: { bolaoId: string }) {
     bets,
     championPicks,
     isChampionPickLocked: isChampionPickLocked(fixtures),
-    leagueWinnerTeamId: getLeagueWinnerTeamId(league),
+    leagueWinnerTeamId,
   }
 }

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -84,7 +84,7 @@ type Team = {
   id: number
   name: string
   logo: string
-  winner: unknown
+  winner: boolean | null
 }
 
 export type ScoreGroup = {

--- a/app/ui/bolao/bet/__tests__/championPickSelector.test.tsx
+++ b/app/ui/bolao/bet/__tests__/championPickSelector.test.tsx
@@ -75,7 +75,7 @@ describe("ChampionPickSelector", () => {
   it("renders label and team options", () => {
     render(<ChampionPickSelector {...baseProps} />)
 
-    expect(screen.getByText("Winner (+500 pts)")).toBeInTheDocument()
+    expect(screen.getByText("Winner (+500 pts) — beta")).toBeInTheDocument()
     expect(screen.getByRole("option", { name: "Brazil" })).toBeInTheDocument()
     expect(screen.getByRole("option", { name: "Mexico" })).toBeInTheDocument()
   })

--- a/messages/en.json
+++ b/messages/en.json
@@ -140,7 +140,7 @@
     "needs": "needs"
   },
   "championPick": {
-    "label": "Winner (+500 pts)",
+    "label": "Winner (+500 pts) — beta",
     "placeholder": "Select a team — optional",
     "selectTeam": "Select championship winner",
     "statusUnlockedNoPick": "Pick the team you think will win. +500 pts if correct. Others' picks hidden until the first game.",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -140,7 +140,7 @@
     "needs": "faltam"
   },
   "championPick": {
-    "label": "Campeão (+500 pts)",
+    "label": "Campeão (+500 pts) — beta",
     "placeholder": "Selecione um time — opcional",
     "selectTeam": "Selecionar campeão do torneio",
     "statusUnlockedNoPick": "Escolha o time campeão. +500 pts se acertar. Palpites dos outros ficam ocultos até o primeiro jogo.",


### PR DESCRIPTION
## Summary

- Fix champion winner resolution: the +500 bonus relied on a `winner` field on the League API seasons object, which API-Football does not return — so the bonus could never be awarded
- Resolve the winner by competition format once the season is finished (no fixture left open to play or in play):
  - **Cup** (World Cup, Champions League...): winner flag on the chronologically last fixture (works after penalties, e.g. 2022 WC final `PEN` — Argentina `winner: true`)
  - **League** (Premier League, Ligue 1...): rank 1 of the standings via the existing `fetchStandings`
- `/standings` is only called once a league season is finished — no extra API quota during the season
- Narrow `Team.winner` from `unknown` to `boolean | null` to match the API payload

## Known limitation

A two-legged final decided on aggregate would mislead the last-fixture heuristic; rare for the competitions this app targets, and an admin winner override is already listed as future work in the design spec.

## Test plan

- Unit tests for `isSeasonFinished`, `getCupWinnerTeamId`, `getLeagueWinnerFromStandings`, `resolveChampionTeamId` (PEN finals, away winners, no-mutation, standings fallbacks)
- Controller tests: cup winner from final fixture, league winner from standings, null winner mid-season without calling `/standings`
- `yarn test` (896 passing)
- `yarn test:e2e` (12 passing)

Made with Cursor


Made with [Cursor](https://cursor.com)