### PR TITLE
feat(seo): improve discoverability for search engines and AI crawlers

### DIFF
--- a/app/__tests__/layout.test.tsx
+++ b/app/__tests__/layout.test.tsx
@@ -48,14 +48,16 @@ vi.mock("../globals.css", () => ({}))
 
 describe("RootLayout", () => {
   describe("Metadata", () => {
-    it("should export metadata with correct title", () => {
-      expect(metadata).toBeDefined()
-      expect(metadata.title).toBe("Bolão.io v3")
-    })
+    const defaultTitle =
+      typeof metadata.title === "object" && metadata.title !== null
+        ? ((metadata.title as { default?: string }).default ?? "")
+        : String(metadata.title)
 
-    it("should export metadata with correct description", () => {
-      expect(metadata).toBeDefined()
-      expect(metadata.description).toBe("Free soccer bets with friends.")
+    it("should export a title with default and template", () => {
+      expect(metadata.title).toBeDefined()
+      expect(metadata.title).toHaveProperty("default")
+      expect(metadata.title).toHaveProperty("template")
+      expect(defaultTitle).toContain("Bolão.io")
     })
 
     it("should have both title and description defined", () => {
@@ -63,30 +65,20 @@ describe("RootLayout", () => {
       expect(metadata).toHaveProperty("description")
     })
 
-    it("should have non-empty title", () => {
-      // Safely check that metadata.title is a non-empty string, accounting for possible types and null/undefined
-      expect(metadata.title).toBeTruthy()
-      expect(typeof metadata.title).toBe("string")
-      expect(
-        typeof metadata.title === "string"
-          ? metadata.title.length
-          : metadata.title?.toString().length
-      ).toBeGreaterThan(0)
+    it("should set metadataBase to the production domain", () => {
+      expect(metadata.metadataBase?.href).toBe("https://bolao.io/")
     })
 
-    it("should have non-empty description", () => {
-      // Safely check that metadata.description is a non-empty string, accounting for possible types and null/undefined
-      expect(metadata.description).toBeTruthy()
-      expect(typeof metadata.description).toBe("string")
-      expect(
-        typeof metadata.description === "string"
-          ? metadata.description.length
-          : 0
-      ).toBeGreaterThan(0)
+    it("should define Open Graph and Twitter cards", () => {
+      expect(metadata.openGraph).toBeDefined()
+      expect(metadata.openGraph?.siteName).toBe("Bolão.io")
+      expect(metadata.twitter).toBeDefined()
+    })
+
+    it("should have SEO-friendly title length", () => {
       // Title should ideally be between 10 and 60 characters for SEO
-      const titleLength = metadata.title?.toString().length || 0
-      expect(titleLength).toBeGreaterThan(5)
-      expect(titleLength).toBeLessThan(70)
+      expect(defaultTitle.length).toBeGreaterThan(5)
+      expect(defaultTitle.length).toBeLessThan(70)
     })
 
     it("should have SEO-friendly description length", () => {

--- a/app/__tests__/news/[uid]/page.test.tsx
+++ b/app/__tests__/news/[uid]/page.test.tsx
@@ -1,47 +1,90 @@
 import { render, screen } from "@testing-library/react"
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import NewsPost from "@/app/news/[uid]/page"
+import NewsPost, { generateMetadata } from "@/app/news/[uid]/page"
 import { createClient } from "@/prismicio"
 
 // Mock dependencies
 vi.mock("@/prismicio")
 
+vi.mock("@prismicio/react", () => ({
+  PrismicRichText: ({ field }: { field: any }) => (
+    <div data-testid="prismic-rich-text">{JSON.stringify(field)}</div>
+  ),
+}))
+
 describe("NewsPost", () => {
-    const mockParams = Promise.resolve({ uid: "test-news-post" })
+  const mockParams = Promise.resolve({ uid: "test-news-post" })
 
-    const mockDocument = {
-        id: "1",
-        uid: "test-news-post",
-        type: "news",
-        data: {
-            title: [{ text: "Test News Title" }],
-            content: [{ text: "Test news content" }]
-        }
-    }
+  const mockDocument = {
+    id: "1",
+    uid: "test-news-post",
+    type: "news",
+    first_publication_date: "2024-01-15T10:00:00+0000",
+    last_publication_date: "2024-01-16T10:00:00+0000",
+    data: {
+      title: [{ type: "heading1", text: "Test News Title", spans: [] }],
+      content: [{ type: "paragraph", text: "Test news content", spans: [] }],
+      meta_title: null,
+      meta_description: null,
+      meta_image: {},
+    },
+  }
 
-    const mockClient = {
-        getByUID: vi.fn()
-    }
+  const mockClient = {
+    getByUID: vi.fn(),
+  }
 
-    beforeEach(() => {
-        vi.clearAllMocks()
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should render the news post article", async () => {
+    ;(createClient as any).mockReturnValue(mockClient)
+    mockClient.getByUID.mockResolvedValue(mockDocument)
+
+    const result = await NewsPost({ params: mockParams })
+    render(result)
+
+    // Title rendered as h1
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Test News Title" })
+    ).toBeInTheDocument()
+
+    // Content rendered through PrismicRichText
+    expect(screen.getByTestId("prismic-rich-text").textContent).toContain(
+      "Test news content"
+    )
+
+    // Verify client methods were called correctly
+    expect(createClient).toHaveBeenCalledOnce()
+    expect(mockClient.getByUID).toHaveBeenCalledWith("news", "test-news-post")
+  })
+
+  it("should generate metadata falling back to document title and content", async () => {
+    ;(createClient as any).mockReturnValue(mockClient)
+    mockClient.getByUID.mockResolvedValue(mockDocument)
+
+    const metadata = await generateMetadata({ params: mockParams })
+
+    expect(metadata.title).toBe("Test News Title")
+    expect(metadata.description).toContain("Test news content")
+    expect(metadata.alternates?.canonical).toBe("/news/test-news-post")
+  })
+
+  it("should prefer Prismic meta fields when present", async () => {
+    ;(createClient as any).mockReturnValue(mockClient)
+    mockClient.getByUID.mockResolvedValue({
+      ...mockDocument,
+      data: {
+        ...mockDocument.data,
+        meta_title: "Custom Meta Title",
+        meta_description: "Custom meta description",
+      },
     })
 
-    it("should render news post document as JSON", async () => {
-        (createClient as any).mockReturnValue(mockClient);
-        mockClient.getByUID.mockResolvedValue(mockDocument);
+    const metadata = await generateMetadata({ params: mockParams })
 
-        const result = await NewsPost({ params: mockParams })
-        render(result)
-
-        // Verify the document is rendered as JSON
-        const preElement = screen.getByText((content, element) => {
-            return element?.tagName.toLowerCase() === 'pre' && content.includes('"uid": "test-news-post"')
-        })
-        expect(preElement).toBeDefined()
-
-        // Verify client methods were called correctly
-        expect(createClient).toHaveBeenCalledOnce()
-        expect(mockClient.getByUID).toHaveBeenCalledWith("news", "test-news-post")
-    })
+    expect(metadata.title).toBe("Custom Meta Title")
+    expect(metadata.description).toBe("Custom meta description")
+  })
 })

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,19 @@
+import type { Metadata } from "next"
 import Link from "next/link"
 import { getTranslations } from "next-intl/server"
 import PageTitle from "@/app/components/pageTitle"
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("about")
+
+  return {
+    title: t("title"),
+    description: t("metaDescription"),
+    alternates: {
+      canonical: "/about",
+    },
+  }
+}
 
 const pClasses = "mb-10"
 const h2Classes = "text-2xl mb-6 text-center"

--- a/app/components/__tests__/footer.test.tsx
+++ b/app/components/__tests__/footer.test.tsx
@@ -4,20 +4,21 @@ import { render } from "@testing-library/react"
 import Footer from "../footer"
 
 describe("Footer", () => {
-  it("should render 4 links", () => {
+  it("should render 5 links", () => {
     render(<Footer />)
 
-    // Check for all 4 links by their text content
+    // Check for all 5 links by their text content
     expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument()
     expect(
       screen.getByRole("link", { name: "Create bolão" })
     ).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "About" })).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "News" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "FAQ" })).toBeInTheDocument()
 
-    // Verify there are exactly 4 links
+    // Verify there are exactly 5 links
     const links = screen.getAllByRole("link")
-    expect(links).toHaveLength(4)
+    expect(links).toHaveLength(5)
   })
 
   it("should have correct href attributes for all links", () => {
@@ -38,6 +39,10 @@ describe("Footer", () => {
     expect(screen.getByRole("link", { name: "News" })).toHaveAttribute(
       "href",
       "/news"
+    )
+    expect(screen.getByRole("link", { name: "FAQ" })).toHaveAttribute(
+      "href",
+      "/faq"
     )
   })
 })

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -24,6 +24,9 @@ function Footer() {
         <Button asChild variant="ghost">
           <Link href="/news">{t("news")}</Link>
         </Button>
+        <Button asChild variant="ghost">
+          <Link href="/faq">{t("faq")}</Link>
+        </Button>
         <LanguageSwitcher />
       </div>
       <BackgroundStripes />

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -6,25 +6,27 @@ import { Button } from "@/components/ui/button"
 import BackgroundStripes from "./backgroundStripes"
 import LanguageSwitcher from "./languageSwitcher"
 
+const footerLinkClassName = "px-2 sm:px-3"
+
 function Footer() {
   const t = useTranslations("common")
 
   return (
     <footer className="mt-20 text-sm">
       <div className="flex space-x-0 mb-4 justify-center items-center">
-        <Button asChild variant="ghost">
+        <Button asChild variant="ghost" className={footerLinkClassName}>
           <Link href="/">{t("home")}</Link>
         </Button>
-        <Button asChild variant="ghost">
+        <Button asChild variant="ghost" className={footerLinkClassName}>
           <Link href="/bolao/create">{t("createBolao")}</Link>
         </Button>
-        <Button asChild variant="ghost">
+        <Button asChild variant="ghost" className={footerLinkClassName}>
           <Link href="/about">{t("about")}</Link>
         </Button>
-        <Button asChild variant="ghost">
+        <Button asChild variant="ghost" className={footerLinkClassName}>
           <Link href="/news">{t("news")}</Link>
         </Button>
-        <Button asChild variant="ghost">
+        <Button asChild variant="ghost" className={footerLinkClassName}>
           <Link href="/faq">{t("faq")}</Link>
         </Button>
         <LanguageSwitcher />

--- a/app/components/jsonLd.tsx
+++ b/app/components/jsonLd.tsx
@@ -1,0 +1,14 @@
+type Props = {
+  data: Record<string, unknown>
+}
+
+function JsonLd({ data }: Props) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}
+
+export default JsonLd

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next"
+import { getTranslations } from "next-intl/server"
+import PageTitle from "@/app/components/pageTitle"
+import JsonLd from "@/app/components/jsonLd"
+
+const QUESTION_KEYS = ["1", "2", "3", "4", "5", "6"] as const
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("faq")
+
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    alternates: {
+      canonical: "/faq",
+    },
+  }
+}
+
+export default async function Faq() {
+  const t = await getTranslations("faq")
+
+  const questions = QUESTION_KEYS.map((key) => ({
+    question: t(`q${key}`),
+    answer: t(`a${key}`),
+  }))
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: questions.map(({ question, answer }) => ({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer,
+      },
+    })),
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <JsonLd data={faqJsonLd} />
+
+      <PageTitle center={true}>
+        <h1>{t("title")}</h1>
+      </PageTitle>
+
+      {questions.map(({ question, answer }) => (
+        <section key={question} className="mb-10">
+          <h2 className="text-2xl mb-4">{question}</h2>
+          <p>{answer}</p>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,8 @@ import Script from "next/script"
 import { Analytics } from "@vercel/analytics/react"
 import { Toaster } from "@/components/ui/toaster"
 import { SpeedInsights } from "@vercel/speed-insights/next"
+import JsonLd from "@/app/components/jsonLd"
+import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from "@/app/lib/siteConfig"
 import "./globals.css"
 
 const Plex = IBM_Plex_Sans({
@@ -19,8 +21,64 @@ const Plex = IBM_Plex_Sans({
 })
 
 export const metadata: Metadata = {
-  title: "Bolão.io v3",
-  description: "Free soccer bets with friends.",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "Bolão.io — Free soccer betting pools with friends",
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  keywords: [
+    "bolão",
+    "bolão online",
+    "bolão grátis",
+    "criar bolão",
+    "soccer betting pool",
+    "football prediction game",
+    "World Cup pool",
+    "Brasileirão",
+  ],
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: "Bolão.io — Free soccer betting pools with friends",
+    description: SITE_DESCRIPTION,
+    locale: "en_US",
+    alternateLocale: "pt_BR",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Bolão.io — Free soccer betting pools with friends",
+    description: SITE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      url: SITE_URL,
+      name: SITE_NAME,
+      description: SITE_DESCRIPTION,
+      inLanguage: ["en", "pt-BR"],
+      publisher: { "@id": `${SITE_URL}/#organization` },
+    },
+    {
+      "@type": "Organization",
+      "@id": `${SITE_URL}/#organization`,
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+  ],
 }
 
 export const viewport = {
@@ -53,6 +111,7 @@ export default async function RootLayout({
           <link rel="preconnect" href="https://clerk.bolao.io" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
           <link rel="dns-prefetch" href="https://media.api-sports.io" />
+          <JsonLd data={websiteJsonLd} />
         </head>
         <body className={Plex.className}>
           <NextIntlClientProvider locale={locale} messages={messages}>

--- a/app/lib/siteConfig.ts
+++ b/app/lib/siteConfig.ts
@@ -1,0 +1,6 @@
+export const SITE_URL = "https://bolao.io"
+
+export const SITE_NAME = "Bolão.io"
+
+export const SITE_DESCRIPTION =
+  "Create a free bolão (soccer betting pool) with friends. Predict match results, track live standings and compete for bragging rights. No money involved, 100% free."

--- a/app/news/[uid]/page.tsx
+++ b/app/news/[uid]/page.tsx
@@ -1,19 +1,92 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+import { asText, asImageSrc } from "@prismicio/client"
+import { PrismicRichText } from "@prismicio/react"
 import { createClient } from "@/prismicio"
+import PageTitle from "@/app/components/pageTitle"
+import JsonLd from "@/app/components/jsonLd"
+import { formatDateNews } from "@/app/lib/utils"
+import { SITE_URL, SITE_NAME } from "@/app/lib/siteConfig"
 
-async function NewsPost(props: any) {
-  const params = await props.params;
+type Props = {
+  params: Promise<{ uid: string }>
+}
+
+async function getDocument(uid: string) {
   const client = createClient()
-  const document = await client.getByUID("news", params.uid)
+  return client.getByUID("news", uid).catch(() => null)
+}
 
-  // console.log({ document })
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { uid } = await props.params
+  const document = await getDocument(uid)
+
+  if (!document) return {}
+
+  const title = document.data.meta_title || asText(document.data.title)
+  const description =
+    document.data.meta_description ||
+    asText(document.data.content).slice(0, 160)
+  const image = asImageSrc(document.data.meta_image)
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/news/${uid}`,
+    },
+    openGraph: {
+      type: "article",
+      title,
+      description,
+      url: `${SITE_URL}/news/${uid}`,
+      publishedTime: document.first_publication_date,
+      modifiedTime: document.last_publication_date,
+      ...(image && { images: [image] }),
+    },
+  }
+}
+
+async function NewsPost(props: Props) {
+  const { uid } = await props.params
+  const document = await getDocument(uid)
+
+  if (!document) notFound()
+
+  const title = asText(document.data.title)
+
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    description:
+      document.data.meta_description ||
+      asText(document.data.content).slice(0, 160),
+    datePublished: document.first_publication_date,
+    dateModified: document.last_publication_date,
+    mainEntityOfPage: `${SITE_URL}/news/${uid}`,
+    author: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+    publisher: { "@id": `${SITE_URL}/#organization` },
+  }
 
   return (
-    <div>
-      <pre>{JSON.stringify(document, null, 2)}</pre>
+    <article className="max-w-2xl mx-auto">
+      <JsonLd data={articleJsonLd} />
 
-      {/* <h1>{document.data.title[0]?.text}</h1>
-      <div>{document.data.content[0]?.text}</div> */}
-    </div>
+      <PageTitle center={true}>
+        <h1>{title}</h1>
+      </PageTitle>
+
+      <div className="text-sm mb-12 text-slate-500 text-center">
+        {formatDateNews(document.first_publication_date)}
+      </div>
+
+      <PrismicRichText field={document.data.content} />
+    </article>
   )
 }
 

--- a/app/news/[uid]/page.tsx
+++ b/app/news/[uid]/page.tsx
@@ -85,7 +85,9 @@ async function NewsPost(props: Props) {
         {formatDateNews(document.first_publication_date)}
       </div>
 
-      <PrismicRichText field={document.data.content} />
+      <div className="news-container">
+        <PrismicRichText field={document.data.content} />
+      </div>
     </article>
   )
 }

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,8 +1,23 @@
+import type { Metadata } from "next"
+import { getTranslations } from "next-intl/server"
 import { createClient } from "@/prismicio"
 import PageTitle from "../components/pageTitle"
 import NewsList from "../ui/news/newsList"
 
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("news")
+
+  return {
+    title: t("title"),
+    description: t("metaDescription"),
+    alternates: {
+      canonical: "/news",
+    },
+  }
+}
+
 async function News() {
+  const t = await getTranslations("news")
   const client = createClient()
   const documents = await client.getAllByType("news", {
     orderings: [
@@ -13,7 +28,7 @@ async function News() {
   return (
     <div className="news-container">
       <PageTitle center={true}>
-        <h1>News</h1>
+        <h1>{t("title")}</h1>
       </PageTitle>
 
       {documents && <NewsList documents={documents} />}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,43 @@
+import { ImageResponse } from "next/og"
+
+export const alt = "Bolão.io — Free soccer betting pools with friends"
+export const size = {
+  width: 1200,
+  height: 630,
+}
+export const contentType = "image/png"
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          color: "#ffffff",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ fontSize: 110, fontWeight: 700 }}>Bolão.io</div>
+        <div
+          style={{
+            fontSize: 38,
+            marginTop: 24,
+            color: "#a1a1aa",
+            textAlign: "center",
+          }}
+        >
+          Free soccer betting pools with friends
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,28 +73,30 @@ async function Home() {
           {t("tagline3")}
         </p>
 
-        <div className="flex items-center justify-center gap-4 mb-4">
-          <Button asChild>
-            <Link href="/sign-up">{t("getStarted")}</Link>
-          </Button>
-          <Button asChild variant="secondary">
-            <Link href="/sign-in">{t("login")}</Link>
-          </Button>
-        </div>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-8 sm:max-w-lg sm:mx-auto">
+          <div className="flex flex-col items-center sm:items-end sm:flex-1 gap-3">
+            <Button asChild>
+              <Link href="/sign-up">{t("getStarted")}</Link>
+            </Button>
+            <Link
+              href="/about"
+              className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
+            >
+              {t("learnMore")}
+            </Link>
+          </div>
 
-        <div className="flex items-center justify-center gap-6">
-          <Link
-            href="/about"
-            className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
-          >
-            {t("learnMore")}
-          </Link>
-          <Link
-            href="/faq"
-            className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
-          >
-            {t("faqLink")}
-          </Link>
+          <div className="flex flex-col items-center sm:items-start sm:flex-1 gap-3">
+            <Button asChild variant="secondary">
+              <Link href="/sign-in">{t("login")}</Link>
+            </Button>
+            <Link
+              href="/faq"
+              className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
+            >
+              {t("faqLink")}
+            </Link>
+          </div>
         </div>
       </div>
 
@@ -111,27 +113,21 @@ async function Home() {
         <h2 className="text-2xl font-bold mb-6 text-center">
           {t("howItWorks")}
         </h2>
-        <div className="grid md:grid-cols-3 gap-8">
+        <div className="grid md:grid-cols-3 gap-4">
           <div className="text-center">
             <div className="text-4xl font-bold text-primary mb-2">1</div>
             <h3 className="font-semibold mb-2">{t("step1Title")}</h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              {t("step1Desc")}
-            </p>
+            <p className="text-gray-600 dark:text-gray-400">{t("step1Desc")}</p>
           </div>
           <div className="text-center">
             <div className="text-4xl font-bold text-primary mb-2">2</div>
             <h3 className="font-semibold mb-2">{t("step2Title")}</h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              {t("step2Desc")}
-            </p>
+            <p className="text-gray-600 dark:text-gray-400">{t("step2Desc")}</p>
           </div>
           <div className="text-center">
             <div className="text-4xl font-bold text-primary mb-2">3</div>
             <h3 className="font-semibold mb-2">{t("step3Title")}</h3>
-            <p className="text-gray-600 dark:text-gray-400">
-              {t("step3Desc")}
-            </p>
+            <p className="text-gray-600 dark:text-gray-400">{t("step3Desc")}</p>
           </div>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,11 +7,30 @@ import { BoloesListSkeleton } from "@/app/ui/skeletons"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import InviteRedirector from "@/app/components/InviteRedirector"
+import JsonLd from "@/app/components/jsonLd"
+import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from "@/app/lib/siteConfig"
 
 // ISR: revalidate cached page every 5 minutes
 export const revalidate = 300
 
 const sectionSpaceing = "mb-18"
+
+const webApplicationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: SITE_NAME,
+  url: SITE_URL,
+  description: SITE_DESCRIPTION,
+  applicationCategory: "SportsApplication",
+  operatingSystem: "Any (web browser)",
+  isAccessibleForFree: true,
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  inLanguage: ["en", "pt-BR"],
+}
 
 async function Home() {
   const user = await currentUser()
@@ -40,6 +59,7 @@ async function Home() {
 
   return (
     <main className="max-w-4xl mx-auto px-4">
+      <JsonLd data={webApplicationJsonLd} />
       <InviteRedirector />
 
       {/* Hero Section */}
@@ -62,12 +82,20 @@ async function Home() {
           </Button>
         </div>
 
-        <Link
-          href="/about"
-          className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
-        >
-          {t("learnMore")}
-        </Link>
+        <div className="flex items-center justify-center gap-6">
+          <Link
+            href="/about"
+            className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
+          >
+            {t("learnMore")}
+          </Link>
+          <Link
+            href="/faq"
+            className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
+          >
+            {t("faqLink")}
+          </Link>
+        </div>
       </div>
 
       {/* What is a Bolão? */}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next"
+import { SITE_URL } from "@/app/lib/siteConfig"
+
+const disallowed = ["/admin", "/bolao", "/api", "/sign-up/db"]
+
+// Explicitly welcome AI assistant crawlers (ChatGPT, Claude, Perplexity, etc.)
+// so bolao.io can be discovered and cited in AI-generated answers.
+const aiCrawlers = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "anthropic-ai",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+]
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: disallowed,
+      },
+      ...aiCrawlers.map((userAgent) => ({
+        userAgent,
+        allow: "/",
+        disallow: disallowed,
+      })),
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,45 @@
+import type { MetadataRoute } from "next"
+import { createClient } from "@/prismicio"
+import { SITE_URL } from "@/app/lib/siteConfig"
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/faq`,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/news`,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+  ]
+
+  let newsRoutes: MetadataRoute.Sitemap = []
+  try {
+    const client = createClient()
+    const documents = await client.getAllByType("news")
+
+    newsRoutes = documents.map((document) => ({
+      url: `${SITE_URL}/news/${document.uid}`,
+      lastModified: new Date(document.last_publication_date),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    }))
+  } catch {
+    // CMS unavailable: still serve the static routes.
+  }
+
+  return [...staticRoutes, ...newsRoutes]
+}

--- a/app/ui/news/__tests__/newsList.test.tsx
+++ b/app/ui/news/__tests__/newsList.test.tsx
@@ -8,12 +8,6 @@ vi.mock("@/app/lib/utils", () => ({
   formatDateNews: vi.fn((_dateString: string) => "January 15, 2024"),
 }))
 
-// Mock PrismicRichText
-vi.mock("@prismicio/react", () => ({
-  PrismicRichText: ({ field }: { field: any }) => (
-    <div data-testid="prismic-rich-text">{JSON.stringify(field)}</div>
-  ),
-}))
 
 describe("NewsList", () => {
   const mockNewsDocument: NewsDocument = {
@@ -78,10 +72,24 @@ describe("NewsList", () => {
       expect(formatDateNews).toHaveBeenCalledWith("2024-01-15T10:00:00+0000")
     })
 
-    it("should render PrismicRichText component", () => {
+    it("should render content excerpt with a link to the article", () => {
       render(<NewsList documents={[mockNewsDocument]} />)
 
-      expect(screen.getByTestId("prismic-rich-text")).toBeInTheDocument()
+      expect(
+        screen.getByText("This is the content of the news article.")
+      ).toBeInTheDocument()
+      expect(screen.getByRole("link", { name: "Read more" })).toHaveAttribute(
+        "href",
+        "/news/test-news-article"
+      )
+    })
+
+    it("should link the title to the article page", () => {
+      render(<NewsList documents={[mockNewsDocument]} />)
+
+      expect(
+        screen.getByRole("link", { name: "Test News Article" })
+      ).toHaveAttribute("href", "/news/test-news-article")
     })
   })
 
@@ -108,7 +116,7 @@ describe("NewsList", () => {
       const { container } = render(<NewsList documents={[mockNewsDocument]} />)
 
       const dateElement = container.querySelector(
-        ".text-sm.mb-12.text-slate-500"
+        ".text-sm.mb-6.text-slate-500"
       )
       expect(dateElement).toBeInTheDocument()
       expect(dateElement?.textContent).toBe("January 15, 2024")
@@ -125,7 +133,7 @@ describe("NewsList", () => {
       const { container } = render(<NewsList documents={[mockNewsDocument]} />)
 
       const dateElement = screen.getByText("January 15, 2024")
-      expect(dateElement.className).toContain("mb-12")
+      expect(dateElement.className).toContain("mb-6")
     })
 
     it("should apply slate-500 text color", () => {
@@ -150,9 +158,7 @@ describe("NewsList", () => {
       const wrapper = container.querySelector(".mb-20")
       expect(wrapper?.querySelector("h2")).toBeInTheDocument()
       expect(wrapper?.querySelector(".text-sm")).toBeInTheDocument()
-      expect(
-        wrapper?.querySelector('[data-testid="prismic-rich-text"]')
-      ).toBeInTheDocument()
+      expect(wrapper?.querySelector("p")).toBeInTheDocument()
     })
   })
 
@@ -226,7 +232,7 @@ describe("NewsList", () => {
       expect(formatDateNews).toHaveBeenCalledTimes(2)
     })
 
-    it("should render multiple PrismicRichText components", () => {
+    it("should render an excerpt and read more link per document", () => {
       const documents: NewsDocument[] = [
         { ...mockNewsDocument, id: "news-1" },
         { ...mockNewsDocument, id: "news-2" },
@@ -235,8 +241,11 @@ describe("NewsList", () => {
 
       render(<NewsList documents={documents} />)
 
-      const richTextComponents = screen.getAllByTestId("prismic-rich-text")
-      expect(richTextComponents).toHaveLength(3)
+      const excerpts = screen.getAllByText(
+        "This is the content of the news article."
+      )
+      expect(excerpts).toHaveLength(3)
+      expect(screen.getAllByRole("link", { name: "Read more" })).toHaveLength(3)
     })
   })
 
@@ -274,8 +283,8 @@ describe("NewsList", () => {
 
       render(<NewsList documents={[document]} />)
 
-      // Should only display first element
-      expect(screen.getByText("First Part")).toBeInTheDocument()
+      // All title parts are joined into a single text
+      expect(screen.getByText("First Part Second Part")).toBeInTheDocument()
     })
 
     it("should handle empty title array", () => {
@@ -413,7 +422,7 @@ describe("NewsList", () => {
   })
 
   describe("Content Integration", () => {
-    it("should pass content field to PrismicRichText", () => {
+    it("should render content as an excerpt", () => {
       const content = [
         {
           type: "paragraph" as const,
@@ -433,8 +442,7 @@ describe("NewsList", () => {
 
       render(<NewsList documents={[document]} />)
 
-      const richText = screen.getByTestId("prismic-rich-text")
-      expect(richText.textContent).toContain(JSON.stringify(content))
+      expect(screen.getByText("Test content paragraph")).toBeInTheDocument()
     })
 
     it("should handle empty content", () => {
@@ -447,10 +455,29 @@ describe("NewsList", () => {
         },
       }
 
-      render(<NewsList documents={[document]} />)
+      const { container } = render(<NewsList documents={[document]} />)
 
-      const richText = screen.getByTestId("prismic-rich-text")
-      expect(richText).toBeInTheDocument()
+      const excerpt = container.querySelector("p")
+      expect(excerpt).toBeInTheDocument()
+      expect(excerpt?.textContent).toBe("")
+    })
+
+    it("should truncate long content in the excerpt", () => {
+      const longText = "A".repeat(500)
+      const document: any = {
+        ...mockNewsDocument,
+        data: {
+          ...mockNewsDocument.data,
+          title: [{ type: "heading1" as const, text: "Test", spans: [] }],
+          content: [{ type: "paragraph" as const, text: longText, spans: [] }],
+        },
+      }
+
+      const { container } = render(<NewsList documents={[document]} />)
+
+      const excerpt = container.querySelector("p")
+      expect(excerpt?.textContent?.length).toBeLessThan(longText.length)
+      expect(excerpt?.textContent?.endsWith("…")).toBe(true)
     })
 
     it("should handle complex content structures", () => {
@@ -481,10 +508,11 @@ describe("NewsList", () => {
         },
       }
 
-      render(<NewsList documents={[document]} />)
+      const { container } = render(<NewsList documents={[document]} />)
 
-      const richText = screen.getByTestId("prismic-rich-text")
-      expect(richText.textContent).toContain(JSON.stringify(complexContent))
+      const excerpt = container.querySelector("p")
+      expect(excerpt?.textContent).toContain("First paragraph")
+      expect(excerpt?.textContent).toContain("Second paragraph")
     })
   })
 

--- a/app/ui/news/newsList.tsx
+++ b/app/ui/news/newsList.tsx
@@ -1,27 +1,46 @@
 "use client"
 
+import Link from "next/link"
+import { useTranslations } from "next-intl"
+import { asText } from "@prismicio/client"
 import { formatDateNews } from "@/app/lib/utils"
-import { PrismicRichText } from "@prismicio/react"
 import type { NewsDocument } from "@/prismicio-types"
 
+const EXCERPT_LENGTH = 240
+
+function excerpt(document: NewsDocument): string {
+  const text = asText(document.data.content)
+  return text.length > EXCERPT_LENGTH
+    ? `${text.slice(0, EXCERPT_LENGTH).trimEnd()}…`
+    : text
+}
+
 function NewsList({ documents }: { documents: NewsDocument[] }) {
+  const t = useTranslations("common")
+
   return (
     <>
-      {documents.map((document: any, index: number) => {
-        return (
-          <div
-            className="mb-20"
-            key={document.id ?? document.uid ?? index}
-          >
-            <h2 className="text-2xl">{document.data.title[0]?.text}</h2>
-            <div className="text-sm mb-12 text-slate-500">
-              {formatDateNews(document.first_publication_date)}
-            </div>
-
-            <PrismicRichText field={document.data.content} />
+      {documents.map((document) => (
+        <article className="mb-20" key={document.id}>
+          <h2 className="text-2xl">
+            <Link href={`/news/${document.uid}`} className="hover:underline">
+              {asText(document.data.title)}
+            </Link>
+          </h2>
+          <div className="text-sm mb-6 text-slate-500">
+            {formatDateNews(document.first_publication_date)}
           </div>
-        )
-      })}
+
+          <p className="mb-4">{excerpt(document)}</p>
+
+          <Link
+            href={`/news/${document.uid}`}
+            className="underline hover:no-underline"
+          >
+            {t("readMore")}
+          </Link>
+        </article>
+      ))}
     </>
   )
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,6 +3,8 @@
     "home": "Home",
     "about": "About",
     "news": "News",
+    "faq": "FAQ",
+    "readMore": "Read more",
     "createBolao": "Create bolão"
   },
   "home": {
@@ -14,6 +16,7 @@
     "getStarted": "GET STARTED",
     "login": "LOGIN",
     "learnMore": "Learn more about Bolão.io",
+    "faqLink": "Frequently asked questions",
     "whatIsBolao": "What is a bolão?",
     "whatIsBolaoDesc": "In Brazil, a bolão is a betting pool between friends around soccer championships. It's very popular during the World Cup and major tournaments. This app makes it easy to create and manage your own - no money involved, just friendly competition!",
     "howItWorks": "How it works",
@@ -41,8 +44,30 @@
     "en": "English",
     "pt-br": "Português (BR)"
   },
+  "news": {
+    "title": "News",
+    "metaDescription": "Product updates and announcements from Bolão.io, the free app for soccer betting pools with friends."
+  },
+  "faq": {
+    "title": "Frequently Asked Questions",
+    "metaTitle": "FAQ — Creating a free bolão",
+    "metaDescription": "Answers to common questions about Bolão.io: what a bolão is, how to create a free soccer betting pool with friends, how scoring works and which competitions are covered.",
+    "q1": "What is a bolão?",
+    "a1": "A bolão is a Brazilian-style prediction pool where friends bet on the results of soccer matches — no bookmakers and no money required. It is hugely popular in Brazil during the World Cup and major championships. On Bolão.io, you predict the score of each match and earn points based on how close you get.",
+    "q2": "How do I create a free bolão online?",
+    "a2": "Create a free account at bolao.io, click \"Create bolão\", give it a name and pick a competition. You get an invite link to share with friends, and the whole process takes less than a minute.",
+    "q3": "Is Bolão.io really free?",
+    "a3": "Yes, 100% free. There are no subscriptions, no hidden costs and no real-money betting. The app never handles money — it only tracks predictions and points. Many groups agree on a prize among themselves, but that happens outside the app.",
+    "q4": "How do friends join my bolão?",
+    "a4": "Share your bolão's invite link. Friends open it, create a free account (or sign in) and are automatically added to your bolão, ready to make their predictions.",
+    "q5": "How does the scoring work?",
+    "a5": "You earn points for each match prediction: 200 points for the exact score, down to 80 points for picking just the right winner, with intermediate values for partially correct predictions like the correct winner and goal difference. You can also pick a championship winner for a 500-point bonus. The leaderboard updates automatically as results come in.",
+    "q6": "Which competitions are supported?",
+    "a6": "Bolão.io covers major competitions such as the World Cup, Brasileirão Série A and B, Copa do Brasil, Copa America, Libertadores, UEFA Champions League, Premier League, La Liga and Ligue 1, with fixtures and results updated automatically."
+  },
   "about": {
     "title": "About",
+    "metaDescription": "The story behind Bolão.io: a free web app for creating soccer betting pools (bolões) with friends, built in Brazil, covering the World Cup, Brasileirão and more.",
     "bolaoTitle": "Bolão?",
     "bolaoDesc1": "In Brazil, a bolão is a betting pool between friends usually around soccer championships. It is very popular during the World Cup and other major tournaments. For the pronunciation check this",
     "wikiPage": "wiki page",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -3,6 +3,8 @@
     "home": "Início",
     "about": "Sobre",
     "news": "Notícias",
+    "faq": "FAQ",
+    "readMore": "Leia mais",
     "createBolao": "Criar bolão"
   },
   "home": {
@@ -14,6 +16,7 @@
     "getStarted": "COMEÇAR",
     "login": "ENTRAR",
     "learnMore": "Saiba mais sobre o Bolão.io",
+    "faqLink": "Perguntas frequentes",
     "whatIsBolao": "O que é um bolão?",
     "whatIsBolaoDesc": "No Brasil, um bolão é uma aposta entre amigos sobre campeonatos de futebol. É muito popular durante a Copa do Mundo e grandes torneios. Este app facilita criar e gerenciar o seu próprio - sem dinheiro envolvido, apenas competição amigável!",
     "howItWorks": "Como funciona",
@@ -41,8 +44,30 @@
     "en": "English",
     "pt-br": "Português (BR)"
   },
+  "news": {
+    "title": "Notícias",
+    "metaDescription": "Novidades e anúncios do Bolão.io, o app grátis para bolões de futebol com os amigos."
+  },
+  "faq": {
+    "title": "Perguntas Frequentes",
+    "metaTitle": "FAQ — Como criar um bolão grátis",
+    "metaDescription": "Respostas às perguntas mais comuns sobre o Bolão.io: o que é um bolão, como criar um bolão de futebol grátis com os amigos, como funciona a pontuação e quais campeonatos estão disponíveis.",
+    "q1": "O que é um bolão?",
+    "a1": "Um bolão é uma aposta entre amigos sobre os resultados de jogos de futebol — sem casas de aposta e sem dinheiro envolvido. É muito popular no Brasil durante a Copa do Mundo e os grandes campeonatos. No Bolão.io, você dá palpites no placar de cada partida e ganha pontos conforme a precisão.",
+    "q2": "Como criar um bolão grátis online?",
+    "a2": "Crie uma conta gratuita em bolao.io, clique em \"Criar bolão\", escolha um nome e um campeonato. Você recebe um link de convite para compartilhar com os amigos, e o processo todo leva menos de um minuto.",
+    "q3": "O Bolão.io é realmente grátis?",
+    "a3": "Sim, 100% grátis. Não há assinaturas, custos ocultos nem apostas com dinheiro real. O app nunca lida com dinheiro — ele apenas registra palpites e pontos. Muitos grupos combinam um prêmio entre si, mas isso acontece fora do app.",
+    "q4": "Como os amigos entram no meu bolão?",
+    "a4": "Compartilhe o link de convite do seu bolão. Os amigos abrem o link, criam uma conta gratuita (ou fazem login) e são adicionados automaticamente ao seu bolão, prontos para dar seus palpites.",
+    "q5": "Como funciona a pontuação?",
+    "a5": "Você ganha pontos por cada palpite: 200 pontos pelo placar exato, até 80 pontos por acertar apenas o vencedor, com valores intermediários para palpites parcialmente corretos, como vencedor e saldo de gols. Também dá para escolher o campeão do torneio e ganhar um bônus de 500 pontos. O ranking atualiza automaticamente conforme os resultados saem.",
+    "q6": "Quais campeonatos estão disponíveis?",
+    "a6": "O Bolão.io cobre grandes competições como Copa do Mundo, Brasileirão Série A e B, Copa do Brasil, Copa América, Libertadores, UEFA Champions League, Premier League, La Liga e Ligue 1, com jogos e resultados atualizados automaticamente."
+  },
   "about": {
     "title": "Sobre",
+    "metaDescription": "A história por trás do Bolão.io: um web app grátis para criar bolões de futebol com os amigos, feito no Brasil, cobrindo Copa do Mundo, Brasileirão e muito mais.",
     "bolaoTitle": "Bolão?",
     "bolaoDesc1": "No Brasil, um bolão é uma aposta entre amigos geralmente sobre campeonatos de futebol. É muito popular durante a Copa do Mundo e outros grandes torneios. Para a pronúncia, confira esta",
     "wikiPage": "página wiki",

--- a/prismicio.ts
+++ b/prismicio.ts
@@ -14,17 +14,11 @@ export const repositoryName =
  *
  * {@link https://prismic.io/docs/route-resolver#route-resolver}
  */
-// TODO: Update the routes array to match your project's route structure.
 const routes: prismic.ClientConfig["routes"] = [
-  // Examples:
-  // {
-  // 	type: "homepage",
-  // 	path: "/",
-  // },
-  // {
-  // 	type: "page",
-  // 	path: "/:uid",
-  // },
+  {
+    type: "news",
+    path: "/news/:uid",
+  },
 ]
 
 /**

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,25 @@
+# Bolão.io
+
+> Bolão.io (https://bolao.io) is a free web app to create and manage a bolão — a Brazilian-style soccer prediction pool played between friends. Users predict match scores for real soccer competitions (World Cup, Brasileirão, Premier League and more), invite friends with a link, and compete on a live leaderboard. It is completely free: no subscriptions, no hidden costs, and no real money betting involved.
+
+## What you can do on Bolão.io
+
+- Create a free bolão for a supported soccer competition in minutes
+- Invite friends to join with a shareable link
+- Predict match results before kickoff and update picks any time before games start
+- Follow automatic live scoring, results and a player leaderboard as matches finish
+- Play in English or Brazilian Portuguese, on any device with a browser (no app download)
+
+## Key facts
+
+- Free to use; the app never handles money or gambling
+- Account sign-up is required to create or join a bolão
+- Match fixtures and results update automatically from official data
+- Made in Brazil, where "bolão" pools are a popular tradition during the World Cup and major tournaments
+
+## Pages
+
+- [Home](https://bolao.io/): what Bolão.io is and how it works
+- [About](https://bolao.io/about): the story behind the project and soccer coverage
+- [FAQ](https://bolao.io/faq): common questions about creating and playing a free bolão
+- [News](https://bolao.io/news): product updates and announcements


### PR DESCRIPTION
## Summary

Makes bolao.io discoverable by ChatGPT, Perplexity, and search engines:

- **Crawler access**: `app/robots.ts` allowing all crawlers plus explicit AI bots (GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended, Bingbot), blocking auth-gated routes; `app/sitemap.ts` with static pages + Prismic news URLs; `public/llms.txt` describing the site for AI crawlers
- **Metadata**: `metadataBase` (https://bolao.io), keyword-rich default title with template, Open Graph/Twitter cards, canonical URLs, generated OG image, and localized per-page metadata for `/about`, `/news`, `/faq` and news articles (now using Prismic's previously-unused `meta_*` fields)
- **Structured data**: JSON-LD for `WebSite`/`Organization` (layout), `WebApplication` with `isAccessibleForFree: true` (landing page), `FAQPage` (FAQ), and `Article` (news posts)
- **Content**: new bilingual `/faq` page with questions phrased the way people ask AI assistants; news list now links to proper `/news/[uid]` article pages (previously a JSON dump stub), with the Prismic route resolver configured

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` — 900/900 tests pass (footer, news list, news detail, and layout metadata tests updated)
- [x] `yarn build` succeeds; `/robots.txt`, `/sitemap.xml`, `/opengraph-image` routes generated
- [x] Smoke-tested production server: robots.txt rules, sitemap with live Prismic URLs, JSON-LD on home/FAQ/news, llms.txt
- [ ] After deploy: verify `bolao.io/robots.txt` and `/sitemap.xml`, submit sitemap to Bing Webmaster Tools and Google Search Console

## Note

The `bolao-full-flow` e2e spec fails when Playwright cold-starts the dev server (lead page request 500s during on-demand compilation) — this also happens on `main` and is unrelated to this PR; it passes against a warm dev server.


Made with [Cursor](https://cursor.com)