### PR TITLE
fix(fixtures): display kickoff times in the user's timezone

### DIFF
--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -89,7 +89,11 @@ describe("utils", () => {
     it("should sort fixtures by date in ascending order", () => {
       const fixtures: Partial<FixtureData>[] = [
         {
-          fixture: { id: 1, date: "2024-03-15T20:00:00Z" } as any,
+          fixture: {
+            id: 1,
+            date: "2024-03-15T20:00:00Z",
+            timestamp: 1710532800,
+          } as any,
           league: { id: 1, name: "Test League", country: "Test" } as any,
           teams: {
             home: { id: 1, name: "Home Team", logo: "" } as any,
@@ -97,7 +101,11 @@ describe("utils", () => {
           },
         },
         {
-          fixture: { id: 2, date: "2024-03-10T18:00:00Z" } as any,
+          fixture: {
+            id: 2,
+            date: "2024-03-10T18:00:00Z",
+            timestamp: 1710093600,
+          } as any,
           league: { id: 1, name: "Test League", country: "Test" } as any,
           teams: {
             home: { id: 3, name: "Home Team 2", logo: "" } as any,
@@ -105,7 +113,11 @@ describe("utils", () => {
           },
         },
         {
-          fixture: { id: 3, date: "2024-03-20T21:00:00Z" } as any,
+          fixture: {
+            id: 3,
+            date: "2024-03-20T21:00:00Z",
+            timestamp: 1710968400,
+          } as any,
           league: { id: 1, name: "Test League", country: "Test" } as any,
           teams: {
             home: { id: 5, name: "Home Team 3", logo: "" } as any,
@@ -124,7 +136,11 @@ describe("utils", () => {
     it("should handle fixtures with the same date", () => {
       const fixtures: Partial<FixtureData>[] = [
         {
-          fixture: { id: 1, date: "2024-03-15T20:00:00Z" } as any,
+          fixture: {
+            id: 1,
+            date: "2024-03-15T20:00:00Z",
+            timestamp: 1710532800,
+          } as any,
           league: { id: 1, name: "Test League", country: "Test" } as any,
           teams: {
             home: { id: 1, name: "Home Team", logo: "" } as any,
@@ -132,7 +148,11 @@ describe("utils", () => {
           },
         },
         {
-          fixture: { id: 2, date: "2024-03-15T20:00:00Z" } as any,
+          fixture: {
+            id: 2,
+            date: "2024-03-15T20:00:00Z",
+            timestamp: 1710532800,
+          } as any,
           league: { id: 1, name: "Test League", country: "Test" } as any,
           teams: {
             home: { id: 3, name: "Home Team 2", logo: "" } as any,
@@ -157,19 +177,53 @@ describe("utils", () => {
   })
 
   describe("formatDateFixtures", () => {
-    it("should format date correctly", () => {
-      const dateString = "2024-03-15T20:30:00Z"
-      const result = formatDateFixtures(dateString)
+    it("should format timestamp in the local timezone", () => {
+      const timestamp = Math.floor(
+        new Date("2024-03-15T20:30:00Z").getTime() / 1000
+      )
+      const result = formatDateFixtures(timestamp)
 
       // The format is "LLL do H:mm" (e.g., "Mar 15th 20:30")
       expect(result).toMatch(/Mar 15th \d{1,2}:\d{2}/)
     })
 
     it("should handle different months", () => {
-      const dateString = "2024-12-25T15:45:00Z"
-      const result = formatDateFixtures(dateString)
+      const timestamp = Math.floor(
+        new Date("2024-12-25T15:45:00Z").getTime() / 1000
+      )
+      const result = formatDateFixtures(timestamp)
 
       expect(result).toMatch(/Dec 25th \d{1,2}:\d{2}/)
+    })
+
+    it("should convert UTC kickoff to Rio local time", () => {
+      const originalTz = process.env.TZ
+      process.env.TZ = "America/Sao_Paulo"
+
+      // 19:00 UTC = 16:00 BRT
+      const timestamp = Math.floor(
+        new Date("2024-06-11T19:00:00Z").getTime() / 1000
+      )
+      const result = formatDateFixtures(timestamp, "en")
+
+      expect(result).toMatch(/Jun 11th 16:00/)
+
+      process.env.TZ = originalTz
+    })
+
+    it("should convert UTC kickoff to Paris local time", () => {
+      const originalTz = process.env.TZ
+      process.env.TZ = "Europe/Paris"
+
+      // 19:00 UTC = 21:00 CEST
+      const timestamp = Math.floor(
+        new Date("2024-06-11T19:00:00Z").getTime() / 1000
+      )
+      const result = formatDateFixtures(timestamp, "en")
+
+      expect(result).toMatch(/Jun 11th 21:00/)
+
+      process.env.TZ = originalTz
     })
   })
 

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -238,9 +238,7 @@ export async function fetchFixtures({
     headers: myHeaders,
   }
 
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-
-  let url = `${FOOTBALL_API_SPORTS}/fixtures?league=${leagueId}&season=${year}&timezone=${timezone}`
+  let url = `${FOOTBALL_API_SPORTS}/fixtures?league=${leagueId}&season=${year}&timezone=UTC`
   if (round) {
     url += `&round=${round}`
   }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -91,10 +91,15 @@ export const getCurrentSeasonObject = (
   return seasons.find((el: Season) => el.current)
 }
 
+function getFixtureTimestamp(fixture: FixtureData["fixture"]): number {
+  if (fixture.timestamp) return fixture.timestamp
+  return Math.floor(new Date(fixture.date).getTime() / 1000)
+}
+
 export function getChampionPickLockDate(fixtures: FixtureData[]): Date | null {
   if (fixtures.length === 0) return null
   const sorted = sortFixtures([...fixtures])
-  return new Date(sorted[0].fixture.date)
+  return new Date(getFixtureTimestamp(sorted[0].fixture) * 1000)
 }
 
 export function isChampionPickLocked(fixtures: FixtureData[]): boolean {
@@ -117,8 +122,8 @@ export function getTeamsFromFixtures(fixtures: FixtureData[]): ChampionTeam[] {
 
 export const sortFixtures = (fixtures: FixtureData[]) => {
   return fixtures.sort((a, b) => {
-    const dateA = new Date(a.fixture.date).getTime()
-    const dateB = new Date(b.fixture.date).getTime()
+    const dateA = getFixtureTimestamp(a.fixture)
+    const dateB = getFixtureTimestamp(b.fixture)
     if (dateA < dateB) return -1
     if (dateA > dateB) return 1
     return 0
@@ -126,10 +131,10 @@ export const sortFixtures = (fixtures: FixtureData[]) => {
 }
 
 export const formatDateFixtures = (
-  dateString: string,
+  timestamp: number,
   locale: string = "en"
 ): string => {
-  const date = new Date(dateString)
+  const date = new Date(timestamp * 1000)
   const dateFnsLocale = dateFnsLocales[locale] || enUS
   return format(date, "LLL do H:mm", { locale: dateFnsLocale })
 }

--- a/app/ui/bolao/__tests__/fixtureDate.test.tsx
+++ b/app/ui/bolao/__tests__/fixtureDate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import { describe, it, expect, vi } from "vitest"
 import FixtureDate from "../fixtureDate"
 import type { FixtureStatus } from "@/app/lib/definitions"
@@ -9,33 +9,35 @@ vi.mock("@/app/lib/utils", async () => {
   const actual = await vi.importActual("@/app/lib/utils")
   return {
     ...actual,
-    formatDateFixtures: vi.fn((date: string) => "Jan 15th 20:00"),
+    formatDateFixtures: vi.fn(() => "Jan 15th 20:00"),
     STATUSES_IN_PLAY: ["1H", "HT", "2H", "ET", "BT", "LIVE"],
     STATUSES_ERROR: ["CANC", "PST", "ABD", "AWD"],
   }
 })
 
 describe("FixtureDate", () => {
-  const mockDate = "2024-01-15T20:00:00Z"
+  const mockTimestamp = 1705348800
 
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe("Normal Date Display", () => {
-    it("should display formatted date for not started fixtures", () => {
+    it("should display formatted date for not started fixtures", async () => {
       const status: FixtureStatus = {
         long: "Not Started",
         short: "NS",
         elapsed: 0,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
-      expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      })
     })
 
-    it("should call formatDateFixtures with correct date", () => {
+    it("should call formatDateFixtures with correct timestamp", async () => {
       const status: FixtureStatus = {
         long: "Not Started",
         short: "NS",
@@ -43,33 +45,39 @@ describe("FixtureDate", () => {
       }
       const mockFormatDateFixtures = vi.mocked(utils.formatDateFixtures)
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
-      expect(mockFormatDateFixtures).toHaveBeenCalledWith(mockDate, "en")
+      await waitFor(() => {
+        expect(mockFormatDateFixtures).toHaveBeenCalledWith(mockTimestamp, "en")
+      })
     })
 
-    it("should display formatted date for TBD status", () => {
+    it("should display formatted date for TBD status", async () => {
       const status: FixtureStatus = {
         long: "Time To Be Defined",
         short: "TBD",
         elapsed: 0,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
-      expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      })
     })
 
-    it("should display formatted date for finished fixtures", () => {
+    it("should display formatted date for finished fixtures", async () => {
       const status: FixtureStatus = {
         long: "Match Finished",
         short: "FT",
         elapsed: 90,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
-      expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      })
     })
   })
 
@@ -81,7 +89,7 @@ describe("FixtureDate", () => {
         elapsed: 30,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("First Half")).toBeInTheDocument()
       expect(screen.queryByText("Jan 15th 20:00")).not.toBeInTheDocument()
@@ -94,7 +102,7 @@ describe("FixtureDate", () => {
         elapsed: 45,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Halftime")).toBeInTheDocument()
     })
@@ -106,7 +114,7 @@ describe("FixtureDate", () => {
         elapsed: 60,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Second Half")).toBeInTheDocument()
     })
@@ -118,7 +126,7 @@ describe("FixtureDate", () => {
         elapsed: 95,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Extra Time")).toBeInTheDocument()
     })
@@ -130,7 +138,7 @@ describe("FixtureDate", () => {
         elapsed: 120,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Penalty Shootout")).toBeInTheDocument()
     })
@@ -142,7 +150,7 @@ describe("FixtureDate", () => {
         elapsed: 75,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("In Play")).toBeInTheDocument()
     })
@@ -154,7 +162,7 @@ describe("FixtureDate", () => {
         elapsed: 30,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       const statusElement = screen.getByText("First Half")
       expect(statusElement).toHaveClass("text-cyan-600")
@@ -169,7 +177,7 @@ describe("FixtureDate", () => {
         elapsed: 0,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Match Cancelled")).toBeInTheDocument()
       expect(screen.queryByText("Jan 15th 20:00")).not.toBeInTheDocument()
@@ -182,7 +190,7 @@ describe("FixtureDate", () => {
         elapsed: 0,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Match Postponed")).toBeInTheDocument()
     })
@@ -194,7 +202,7 @@ describe("FixtureDate", () => {
         elapsed: 60,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Match Abandoned")).toBeInTheDocument()
     })
@@ -206,7 +214,7 @@ describe("FixtureDate", () => {
         elapsed: 0,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Match Awarded")).toBeInTheDocument()
     })
@@ -218,7 +226,7 @@ describe("FixtureDate", () => {
         elapsed: 0,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       const statusElement = screen.getByText("Match Cancelled")
       expect(statusElement).toHaveClass("text-orange-500")
@@ -234,7 +242,7 @@ describe("FixtureDate", () => {
       }
 
       const { container } = render(
-        <FixtureDate date={mockDate} status={status} />
+        <FixtureDate timestamp={mockTimestamp} status={status} />
       )
 
       const div = container.firstChild
@@ -249,7 +257,7 @@ describe("FixtureDate", () => {
       }
 
       const { container } = render(
-        <FixtureDate date={mockDate} status={status} />
+        <FixtureDate timestamp={mockTimestamp} status={status} />
       )
 
       const div = container.querySelector(".text-xs.text-center")
@@ -259,14 +267,13 @@ describe("FixtureDate", () => {
 
   describe("Status Priority", () => {
     it("should prioritize error status over in-play", () => {
-      // If a status is both in error list and in-play list (edge case)
       const status: FixtureStatus = {
         long: "Match Cancelled",
         short: "CANC",
         elapsed: 30,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Match Cancelled")).toBeInTheDocument()
       const statusElement = screen.getByText("Match Cancelled")
@@ -281,7 +288,7 @@ describe("FixtureDate", () => {
         elapsed: 70,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
       expect(screen.getByText("Second Half")).toBeInTheDocument()
       const statusElement = screen.getByText("Second Half")
@@ -290,26 +297,26 @@ describe("FixtureDate", () => {
   })
 
   describe("Date Formatting", () => {
-    it("should handle different date formats", () => {
-      const dates = [
-        "2024-01-15T20:00:00Z",
-        "2024-12-31T23:59:59Z",
-        "2024-06-15T12:00:00Z",
-      ]
+    it("should handle different timestamps", async () => {
+      const timestamps = [1705348800, 1735689599, 1718452800]
 
-      dates.forEach((date) => {
+      for (const timestamp of timestamps) {
         const status: FixtureStatus = {
           long: "Not Started",
           short: "NS",
           elapsed: 0,
         }
-        const { unmount } = render(<FixtureDate date={date} status={status} />)
-        expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+        const { unmount } = render(
+          <FixtureDate timestamp={timestamp} status={status} />
+        )
+        await waitFor(() => {
+          expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+        })
         unmount()
-      })
+      }
     })
 
-    it("should convert date to string before formatting", () => {
+    it("should call formatDateFixtures after mount", async () => {
       const status: FixtureStatus = {
         long: "Not Started",
         short: "NS",
@@ -317,10 +324,11 @@ describe("FixtureDate", () => {
       }
       const mockFormatDateFixtures = vi.mocked(utils.formatDateFixtures)
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
-      // Should call formatDateFixtures with string
-      expect(mockFormatDateFixtures).toHaveBeenCalled()
+      await waitFor(() => {
+        expect(mockFormatDateFixtures).toHaveBeenCalled()
+      })
     })
   })
 
@@ -333,14 +341,14 @@ describe("FixtureDate", () => {
       }
 
       const { container } = render(
-        <FixtureDate date={mockDate} status={status} />
+        <FixtureDate timestamp={mockTimestamp} status={status} />
       )
 
       const div = container.querySelector("div")
       expect(div).toBeInTheDocument()
     })
 
-    it("should render content directly when showing formatted date", () => {
+    it("should render content in a span when showing formatted date", async () => {
       const status: FixtureStatus = {
         long: "Not Started",
         short: "NS",
@@ -348,11 +356,13 @@ describe("FixtureDate", () => {
       }
 
       const { container } = render(
-        <FixtureDate date={mockDate} status={status} />
+        <FixtureDate timestamp={mockTimestamp} status={status} />
       )
 
-      const div = container.querySelector("div")
-      expect(div?.textContent).toBe("Jan 15th 20:00")
+      await waitFor(() => {
+        const span = container.querySelector("span")
+        expect(span?.textContent).toBe("Jan 15th 20:00")
+      })
     })
 
     it("should render span for error status", () => {
@@ -363,7 +373,7 @@ describe("FixtureDate", () => {
       }
 
       const { container } = render(
-        <FixtureDate date={mockDate} status={status} />
+        <FixtureDate timestamp={mockTimestamp} status={status} />
       )
 
       const span = container.querySelector("span.text-orange-500")
@@ -378,7 +388,7 @@ describe("FixtureDate", () => {
       }
 
       const { container } = render(
-        <FixtureDate date={mockDate} status={status} />
+        <FixtureDate timestamp={mockTimestamp} status={status} />
       )
 
       const span = container.querySelector("span.text-cyan-600")
@@ -395,23 +405,24 @@ describe("FixtureDate", () => {
       }
 
       const { container } = render(
-        <FixtureDate date={mockDate} status={status} />
+        <FixtureDate timestamp={mockTimestamp} status={status} />
       )
 
       expect(container).toBeInTheDocument()
     })
 
-    it("should handle unknown status codes", () => {
+    it("should handle unknown status codes", async () => {
       const status: FixtureStatus = {
         long: "Unknown Status",
         short: "UNK",
         elapsed: 0,
       }
 
-      render(<FixtureDate date={mockDate} status={status} />)
+      render(<FixtureDate timestamp={mockTimestamp} status={status} />)
 
-      // Should default to showing formatted date
-      expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText("Jan 15th 20:00")).toBeInTheDocument()
+      })
     })
   })
 })

--- a/app/ui/bolao/bet/__tests__/tableMatchDayBets.test.tsx
+++ b/app/ui/bolao/bet/__tests__/tableMatchDayBets.test.tsx
@@ -40,9 +40,9 @@ vi.mock("@/app/ui/bolao/teamScore", () => ({
 }))
 
 vi.mock("@/app/ui/bolao/fixtureDate", () => ({
-  default: ({ date, status }: { date: string; status: any }) => (
-    <div data-testid="fixture-date" data-date={date}>
-      {date}
+  default: ({ timestamp, status }: { timestamp: number; status: any }) => (
+    <div data-testid="fixture-date" data-timestamp={timestamp}>
+      {timestamp}
     </div>
   ),
 }))
@@ -378,11 +378,11 @@ describe("TableMatchDayBets", () => {
       expect(screen.getByTestId("fixture-date")).toBeInTheDocument()
     })
 
-    it("should pass correct date to FixtureDate component", async () => {
+    it("should pass correct timestamp to FixtureDate component", async () => {
       await renderTableMatchDayBets(defaultProps)
 
       const fixtureDate = screen.getByTestId("fixture-date")
-      expect(fixtureDate).toHaveAttribute("data-date")
+      expect(fixtureDate).toHaveAttribute("data-timestamp", "1705348800")
     })
   })
 

--- a/app/ui/bolao/bet/championPickSelector.tsx
+++ b/app/ui/bolao/bet/championPickSelector.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslations } from "next-intl"
 import { ChampionTeam, ChampionPick } from "@/app/lib/definitions"
 import { createOrUpdateChampionPick } from "@/app/lib/actions"
@@ -50,6 +50,17 @@ function ChampionPickSelector({
     userChampionPick ? String(userChampionPick.team_id) : undefined
   )
   const [isSaving, setIsSaving] = useState(false)
+  const [formattedLockDate, setFormattedLockDate] = useState("")
+
+  // Format after mount so the date is rendered in the user's timezone,
+  // avoiding an SSR/client hydration mismatch.
+  useEffect(() => {
+    if (lockDate) {
+      setFormattedLockDate(
+        formatDateFixtures(Math.floor(lockDate.getTime() / 1000), locale)
+      )
+    }
+  }, [lockDate, locale])
 
   const handleChange = async (teamIdStr: string) => {
     const team = teams.find((entry) => entry.id === Number(teamIdStr))
@@ -113,7 +124,7 @@ function ChampionPickSelector({
     if (savedPick) {
       return t("statusUnlockedHasPick", {
         team: savedPick.name,
-        date: lockDate ? formatDateFixtures(lockDate.toISOString(), locale) : "",
+        date: formattedLockDate,
       })
     }
 

--- a/app/ui/bolao/bet/tableMatchDayBets.tsx
+++ b/app/ui/bolao/bet/tableMatchDayBets.tsx
@@ -87,7 +87,7 @@ async function TableMatchDayBets({
 
                     <div className="flex flex-col items-center">
                       <FixtureDate
-                        date={fixtureData.fixture.date.toString()}
+                        timestamp={fixtureData.fixture.timestamp}
                         status={fixtureData.fixture.status}
                         locale={locale}
                       />

--- a/app/ui/bolao/fixtureDate.tsx
+++ b/app/ui/bolao/fixtureDate.tsx
@@ -1,3 +1,6 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import {
   STATUSES_IN_PLAY,
   STATUSES_ERROR,
@@ -7,16 +10,19 @@ import { FixtureStatus } from "@/app/lib/definitions"
 import clsx from "clsx"
 
 type Props = {
-  date: string
+  timestamp: number
   status: FixtureStatus
   locale?: string
 }
 
-function FixtureDate({ date, status, locale = "en" }: Props) {
+function FixtureDate({ timestamp, status, locale = "en" }: Props) {
   const inPlay = STATUSES_IN_PLAY.includes(status.short)
   const hasError = STATUSES_ERROR.includes(status.short)
+  const [formattedDate, setFormattedDate] = useState("")
 
-  const formatedDate = formatDateFixtures(date.toString(), locale)
+  useEffect(() => {
+    setFormattedDate(formatDateFixtures(timestamp, locale))
+  }, [timestamp, locale])
 
   return (
     <div className="text-xs text-center">
@@ -33,7 +39,7 @@ function FixtureDate({ date, status, locale = "en" }: Props) {
       ) : inPlay ? (
         <span className="text-cyan-600">{status.long}</span>
       ) : (
-        formatedDate
+        <span suppressHydrationWarning>{formattedDate || "\u00a0"}</span>
       )}
     </div>
   )

--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -155,7 +155,7 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
                       />
                       <div>
                         <FixtureDate
-                          date={fixtureData.fixture.date.toString()}
+                          timestamp={fixtureData.fixture.timestamp}
                           status={fixtureData.fixture.status}
                           locale={locale}
                         />


### PR DESCRIPTION
## Summary

Users were seeing fixture kickoff times in the server's timezone instead of their own (e.g. a 16h BRT match in Rio de Janeiro displayed as 19h, the UTC time).

- Fetch fixtures from API-Football with `timezone=UTC` instead of resolving `Intl.DateTimeFormat()` on the server (which yielded the server's timezone, not the visitor's).
- Use the timezone-independent unix `fixture.timestamp` for sorting and champion-pick lock-date logic (with a fallback to parsing `fixture.date`).
- Make `FixtureDate` a client component that formats the date in a `useEffect` after mount, so `date-fns` runs in the browser and renders the visitor's local time (with a placeholder + `suppressHydrationWarning` to avoid hydration mismatches).
- Apply the same mount-then-format pattern to the champion pick lock date in `ChampionPickSelector`.
- Add regression tests encoding the reported scenario: 19:00 UTC renders as 16:00 in `America/Sao_Paulo` and 21:00 in `Europe/Paris`.

## Test plan

- [x] `yarn test` — 902 tests pass (56 files)
- [x] `yarn test:e2e` — 12 tests pass (via pre-push hook)
- [ ] Verify on preview deployment from Rio (UTC-3) that kickoff times show local time (16h, not 19h)
- [ ] Verify from a European timezone that times shift accordingly
- [ ] Check browser console for hydration errors on bet and results pages

Made with [Cursor](https://cursor.com)