### PR TITLE
fix(ui): polish results table spacing and sticky totals corner

### DIFF
--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -96,166 +96,166 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-          <StickyTable borderWidth={0}>
-            <Row>
-              <Cell style={{ ...cellStyles, backgroundColor: "white" }}>
-                &nbsp;
-              </Cell>
-              {players.map((player: PlayersData) => {
-                return (
-                  <Cell style={cellStyles} key={player.id}>
-                    <span className="font-semibold text-sm px-2">
-                      {player.username || getEmailUsername(player.email)}
-                    </span>
-                  </Cell>
-                )
-              })}
-            </Row>
+            <StickyTable borderWidth={0}>
+              <Row>
+                <Cell style={{ ...cellStyles, backgroundColor: "white" }}>
+                  &nbsp;
+                </Cell>
+                {players.map((player: PlayersData) => {
+                  return (
+                    <Cell style={cellStyles} key={player.id}>
+                      <span className="font-semibold text-sm px-2">
+                        {player.username || getEmailUsername(player.email)}
+                      </span>
+                    </Cell>
+                  )
+                })}
+              </Row>
 
-            {fixtures.map((fixtureData: FixtureData, i: number) => {
-              const statusShort = fixtureData.fixture.status.short
-              const canShowScores =
-                STATUSES_IN_PLAY.includes(statusShort) ||
-                STATUSES_FINISHED.includes(statusShort)
+              {fixtures.map((fixtureData: FixtureData, i: number) => {
+                const statusShort = fixtureData.fixture.status.short
+                const canShowScores =
+                  STATUSES_IN_PLAY.includes(statusShort) ||
+                  STATUSES_FINISHED.includes(statusShort)
 
-              const getBet = ({
-                type,
-                userBolaoId,
-              }: {
-                type: "home" | "away"
-                userBolaoId: string
-              }) => {
-                const obj = findBetObj({
-                  bets,
-                  fixtureId: fixtureData.fixture.id.toString(),
+                const getBet = ({
                   type,
                   userBolaoId,
-                })
+                }: {
+                  type: "home" | "away"
+                  userBolaoId: string
+                }) => {
+                  const obj = findBetObj({
+                    bets,
+                    fixtureId: fixtureData.fixture.id.toString(),
+                    type,
+                    userBolaoId,
+                  })
 
-                if (obj) {
-                  return obj.value.toString()
+                  if (obj) {
+                    return obj.value.toString()
+                  }
+                  return INITIAL_BET_VALUE
                 }
-                return INITIAL_BET_VALUE
-              }
 
-              return (
-                <Row key={fixtureData.fixture.id}>
-                  <Cell
-                    style={{
-                      padding: "8px 0",
-                      margin: 0,
-                      border: 0,
-                      backgroundColor: i % 2 !== 0 ? "rgb(248 250 252)" : "", //bg-slate-50
-                    }}
-                  >
-                    <div className="flex justify-center content-center">
-                      <TeamCodeLogo
-                        logoSrc={fixtureData.teams.home.logo}
-                        name={fixtureData.teams.home.name}
-                      />
-                      <div>
-                        <FixtureDate
-                          timestamp={fixtureData.fixture.timestamp}
-                          status={fixtureData.fixture.status}
-                          locale={locale}
-                        />
-                        <div className="flex flex-row">
-                          <TeamScore
-                            score={fixtureData.score}
-                            goals={fixtureData.goals}
-                            type="home"
-                            status={statusShort}
-                          />
-
-                          <span className="mx-3 text-xs content-center">
-                            &times;
-                          </span>
-
-                          <TeamScore
-                            score={fixtureData.score}
-                            goals={fixtureData.goals}
-                            type="away"
-                            status={statusShort}
-                          />
-                        </div>
-                      </div>
-                      <TeamCodeLogo
-                        logoSrc={fixtureData.teams.away.logo}
-                        name={fixtureData.teams.away.name}
-                      />
-                    </div>
-                  </Cell>
-
-                  {players.map((player) => {
-                    const showScores = player.id === userId || canShowScores
-
-                    const betHome = getBet({
-                      type: "home",
-                      userBolaoId: player.userBolaoId,
-                    })
-                    const betAway = getBet({
-                      type: "away",
-                      userBolaoId: player.userBolaoId,
-                    })
-
-                    let score = 0
-                    if (canShowScores) {
-                      const fulltime = fixtureData.score.fulltime
-                      const halftime = fixtureData.score.halftime
-
-                      score = calcScore({
-                        resultHome: fulltime.home || halftime.home || 0,
-                        resultAway: fulltime.away || halftime.away || 0,
-                        betHome: Number(betHome),
-                        betAway: Number(betAway),
-                      })
-                    }
-
-                    return (
-                      <Cell
-                        style={{
-                          padding: 0,
-                          margin: 0,
-                          border: 0,
-                          backgroundColor:
-                            i % 2 !== 0 ? "rgb(248 250 252)" : "",
-                        }}
-                        key={`${fixtureData.fixture.id}_${player.id}`}
-                        className="text-center"
-                      >
-                        <div>
-                          {showScores ? betHome : INITIAL_BET_VALUE}-
-                          {showScores ? betAway : INITIAL_BET_VALUE}
-                        </div>
-                        {canShowScores && (
-                          <div className="text-sm">{`${score} pts`}</div>
-                        )}
-                      </Cell>
-                    )
-                  })}
-                </Row>
-              )
-            })}
-
-            <Row>
-              <Cell style={totalsCellStyles}>
-                <div className="text-left pl-6">{t("total")}</div>
-              </Cell>
-              {players.map((player) => {
-                const total = calculatePlayerTotal(player.userBolaoId)
                 return (
-                  <Cell
-                    style={totalsCellStyles}
-                    key={`total_${player.id}`}
-                    className="text-center"
-                  >
-                    <div className="text-sm">{`${total} pts`}</div>
-                  </Cell>
+                  <Row key={fixtureData.fixture.id}>
+                    <Cell
+                      style={{
+                        padding: "8px 0",
+                        margin: 0,
+                        border: 0,
+                        backgroundColor: i % 2 !== 0 ? "rgb(248 250 252)" : "", //bg-slate-50
+                      }}
+                    >
+                      <div className="flex justify-center content-center">
+                        <TeamCodeLogo
+                          logoSrc={fixtureData.teams.home.logo}
+                          name={fixtureData.teams.home.name}
+                        />
+                        <div>
+                          <FixtureDate
+                            timestamp={fixtureData.fixture.timestamp}
+                            status={fixtureData.fixture.status}
+                            locale={locale}
+                          />
+                          <div className="flex flex-row">
+                            <TeamScore
+                              score={fixtureData.score}
+                              goals={fixtureData.goals}
+                              type="home"
+                              status={statusShort}
+                            />
+
+                            <span className="mx-3 text-xs content-center">
+                              &times;
+                            </span>
+
+                            <TeamScore
+                              score={fixtureData.score}
+                              goals={fixtureData.goals}
+                              type="away"
+                              status={statusShort}
+                            />
+                          </div>
+                        </div>
+                        <TeamCodeLogo
+                          logoSrc={fixtureData.teams.away.logo}
+                          name={fixtureData.teams.away.name}
+                        />
+                      </div>
+                    </Cell>
+
+                    {players.map((player) => {
+                      const showScores = player.id === userId || canShowScores
+
+                      const betHome = getBet({
+                        type: "home",
+                        userBolaoId: player.userBolaoId,
+                      })
+                      const betAway = getBet({
+                        type: "away",
+                        userBolaoId: player.userBolaoId,
+                      })
+
+                      let score = 0
+                      if (canShowScores) {
+                        const fulltime = fixtureData.score.fulltime
+                        const halftime = fixtureData.score.halftime
+
+                        score = calcScore({
+                          resultHome: fulltime.home || halftime.home || 0,
+                          resultAway: fulltime.away || halftime.away || 0,
+                          betHome: Number(betHome),
+                          betAway: Number(betAway),
+                        })
+                      }
+
+                      return (
+                        <Cell
+                          style={{
+                            padding: 0,
+                            margin: 0,
+                            border: 0,
+                            backgroundColor:
+                              i % 2 !== 0 ? "rgb(248 250 252)" : "",
+                          }}
+                          key={`${fixtureData.fixture.id}_${player.id}`}
+                          className="text-center"
+                        >
+                          <div>
+                            {showScores ? betHome : INITIAL_BET_VALUE}-
+                            {showScores ? betAway : INITIAL_BET_VALUE}
+                          </div>
+                          {canShowScores && (
+                            <div className="text-sm px-2">{`${score} pts`}</div>
+                          )}
+                        </Cell>
+                      )
+                    })}
+                  </Row>
                 )
               })}
-            </Row>
-          </StickyTable>
-        </CardContent>
+
+              <Row>
+                <Cell style={{ ...totalsCellStyles, backgroundColor: "white" }}>
+                  <div className="text-left pl-6">{t("total")}</div>
+                </Cell>
+                {players.map((player) => {
+                  const total = calculatePlayerTotal(player.userBolaoId)
+                  return (
+                    <Cell
+                      style={totalsCellStyles}
+                      key={`total_${player.id}`}
+                      className="text-center"
+                    >
+                      <div className="text-sm">{`${total} pts`}</div>
+                    </Cell>
+                  )
+                })}
+              </Row>
+            </StickyTable>
+          </CardContent>
         </Card>
       </div>
     )


### PR DESCRIPTION
## Summary
- Add small horizontal padding (`px-2`) to the per-fixture score (`X pts`) in the results table cells
- Give the totals-row sticky corner cell a white background so content doesn't show through when scrolling
- Re-indent the `CardContent` block in `tableMatchDayResults.tsx` (formatting only)

## Test plan
- [ ] Open a bolão results page and verify the `pts` labels have breathing room in narrow columns
- [ ] Scroll the results table horizontally and verify the totals-row corner cell stays opaque

Made with [Cursor](https://cursor.com)