### PR TITLE
fix(ui): keep results table header visible during horizontal scroll

### DIFF
--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -32,11 +32,17 @@ const cellStyles = {
   backgroundColor: "transparent",
 }
 
+const headerCellStyles = {
+  ...cellStyles,
+  backgroundColor: "white",
+}
+
 const totalsCellStyles = {
   ...cellStyles,
   borderTop: "1px solid rgb(226 232 240)", // border-slate-200
   padding: "12px 0",
   fontWeight: 600,
+  backgroundColor: "white",
 }
 
 function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
@@ -96,14 +102,13 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <StickyTable borderWidth={0}>
+            <div className="h-[min(70vh,800px)] w-full max-md:h-[55vh]">
+              <StickyTable borderWidth={0} stickyFooterCount={1}>
               <Row>
-                <Cell style={{ ...cellStyles, backgroundColor: "white" }}>
-                  &nbsp;
-                </Cell>
+                <Cell style={headerCellStyles}>&nbsp;</Cell>
                 {players.map((player: PlayersData) => {
                   return (
-                    <Cell style={cellStyles} key={player.id}>
+                    <Cell style={headerCellStyles} key={player.id}>
                       <span className="font-semibold text-sm px-2">
                         {player.username || getEmailUsername(player.email)}
                       </span>
@@ -238,7 +243,7 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
               })}
 
               <Row>
-                <Cell style={{ ...totalsCellStyles, backgroundColor: "white" }}>
+                <Cell style={totalsCellStyles}>
                   <div className="text-left pl-6">{t("total")}</div>
                 </Cell>
                 {players.map((player) => {
@@ -255,6 +260,7 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
                 })}
               </Row>
             </StickyTable>
+            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary

- Wraps `StickyTable` in a bounded scroll container (`70vh` on desktop, `55vh` on mobile) so vertical and horizontal scrolling happen inside the table instead of on the page.
- Enables `stickyFooterCount={1}` so the totals row stays pinned at the bottom of the table area.
- Gives header and footer cells solid white backgrounds to prevent content bleed-through while scrolling.

Fixes the issue where users on Windows (and other platforms) had to scroll to the bottom of a long fixture list to reach the horizontal scrollbar, losing sight of player names in the header.

## Test plan

- [ ] Open a bolão results page with many players and fixtures
- [ ] Confirm player names stay visible while scrolling vertically through matches
- [ ] Confirm the horizontal scrollbar is reachable without scrolling the whole page
- [ ] Confirm the match/fixture column stays visible when scrolling horizontally
- [ ] Confirm the totals row stays pinned at the bottom of the table area
- [x] `yarn test app/ui/bolao/results/__tests__/tableMatchDayResults.test.tsx`
- [x] `yarn build`


Made with [Cursor](https://cursor.com)