### PR TITLE
docs(faq): expand scoring answer with full point tier breakdown

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -4,6 +4,25 @@ import PageTitle from "@/app/components/pageTitle"
 import JsonLd from "@/app/components/jsonLd"
 
 const QUESTION_KEYS = ["1", "2", "3", "4", "5", "6"] as const
+const SCORING_TIER_KEYS = [
+  "tierExact",
+  "tierWinnerScore",
+  "tierDraw",
+  "tierWinnerLoser",
+  "tierGoalDiff",
+  "tierWinnerOnly",
+] as const
+
+type FaqTranslator = Awaited<ReturnType<typeof getTranslations<"faq">>>
+
+function getScoringAnswerText(t: FaqTranslator): string {
+  return [
+    t("scoring.intro"),
+    ...SCORING_TIER_KEYS.map((key) => t(`scoring.${key}`)),
+    t("scoring.championBonus"),
+    t("scoring.outro"),
+  ].join(" ")
+}
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("faq")
@@ -21,8 +40,9 @@ export default async function Faq() {
   const t = await getTranslations("faq")
 
   const questions = QUESTION_KEYS.map((key) => ({
+    key,
     question: t(`q${key}`),
-    answer: t(`a${key}`),
+    answer: key === "5" ? getScoringAnswerText(t) : t(`a${key}`),
   }))
 
   const faqJsonLd = {
@@ -46,10 +66,23 @@ export default async function Faq() {
         <h1>{t("title")}</h1>
       </PageTitle>
 
-      {questions.map(({ question, answer }) => (
+      {questions.map(({ key, question, answer }) => (
         <section key={question} className="mb-10">
           <h2 className="text-2xl mb-4">{question}</h2>
-          <p>{answer}</p>
+          {key === "5" ? (
+            <>
+              <p className="mb-4">{t("scoring.intro")}</p>
+              <ul className="list-disc pl-6 mb-4 space-y-2">
+                {SCORING_TIER_KEYS.map((tierKey) => (
+                  <li key={tierKey}>{t(`scoring.${tierKey}`)}</li>
+                ))}
+              </ul>
+              <p className="mb-4">{t("scoring.championBonus")}</p>
+              <p>{t("scoring.outro")}</p>
+            </>
+          ) : (
+            <p>{answer}</p>
+          )}
         </section>
       ))}
     </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -61,7 +61,17 @@
     "q4": "How do friends join my bolão?",
     "a4": "Share your bolão's invite link. Friends open it, create a free account (or sign in) and are automatically added to your bolão, ready to make their predictions.",
     "q5": "How does the scoring work?",
-    "a5": "You earn points for each match prediction: 200 points for the exact score, down to 80 points for picking just the right winner, with intermediate values for partially correct predictions like the correct winner and goal difference. You can also pick a championship winner for a 500-point bonus. The leaderboard updates automatically as results come in.",
+    "scoring": {
+      "intro": "You earn points for each match prediction. The highest matching rule applies:",
+      "tierExact": "200 pts — Exact score (e.g. result 3-0, your bet 3-0)",
+      "tierWinnerScore": "150 pts — Winner's goals correct (e.g. result 3-0, your bet 3-1)",
+      "tierDraw": "150 pts — Draw predicted, not exact (e.g. result 1-1, your bet 0-0)",
+      "tierWinnerLoser": "120 pts — Winner and loser's goals (e.g. result 3-1, your bet 2-1)",
+      "tierGoalDiff": "100 pts — Winner and goal difference (e.g. result 2-1, your bet 1-0)",
+      "tierWinnerOnly": "80 pts — Winner only (e.g. result 1-0, your bet 3-2)",
+      "championBonus": "Pick the championship winner for a one-time +500 pt bonus added to your leaderboard total.",
+      "outro": "The leaderboard updates automatically as results come in."
+    },
     "q6": "Which competitions are supported?",
     "a6": "Bolão.io covers major competitions such as the World Cup, Brasileirão Série A and B, Copa do Brasil, Copa America, Libertadores, UEFA Champions League, Premier League, La Liga and Ligue 1, with fixtures and results updated automatically."
   },

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -61,7 +61,17 @@
     "q4": "Como os amigos entram no meu bolão?",
     "a4": "Compartilhe o link de convite do seu bolão. Os amigos abrem o link, criam uma conta gratuita (ou fazem login) e são adicionados automaticamente ao seu bolão, prontos para dar seus palpites.",
     "q5": "Como funciona a pontuação?",
-    "a5": "Você ganha pontos por cada palpite: 200 pontos pelo placar exato, até 80 pontos por acertar apenas o vencedor, com valores intermediários para palpites parcialmente corretos, como vencedor e saldo de gols. Também dá para escolher o campeão do torneio e ganhar um bônus de 500 pontos. O ranking atualiza automaticamente conforme os resultados saem.",
+    "scoring": {
+      "intro": "Você ganha pontos por cada palpite. Vale a regra de maior pontuação que se aplicar:",
+      "tierExact": "200 pts — Placar exato (ex.: resultado 3-0, seu palpite 3-0)",
+      "tierWinnerScore": "150 pts — Gols do vencedor corretos (ex.: resultado 3-0, seu palpite 3-1)",
+      "tierDraw": "150 pts — Empate previsto, mas não exato (ex.: resultado 1-1, seu palpite 0-0)",
+      "tierWinnerLoser": "120 pts — Vencedor e gols do perdedor (ex.: resultado 3-1, seu palpite 2-1)",
+      "tierGoalDiff": "100 pts — Vencedor e saldo de gols (ex.: resultado 2-1, seu palpite 1-0)",
+      "tierWinnerOnly": "80 pts — Apenas o vencedor (ex.: resultado 1-0, seu palpite 3-2)",
+      "championBonus": "Escolha o campeão do torneio para um bônus único de +500 pts somado ao seu total no ranking.",
+      "outro": "O ranking atualiza automaticamente conforme os resultados saem."
+    },
     "q6": "Quais campeonatos estão disponíveis?",
     "a6": "O Bolão.io cobre grandes competições como Copa do Mundo, Brasileirão Série A e B, Copa do Brasil, Copa América, Libertadores, UEFA Champions League, Premier League, La Liga e Ligue 1, com jogos e resultados atualizados automaticamente."
   },


### PR DESCRIPTION
## Summary
- Replace the FAQ Q5 summary paragraph with a structured list of all six match scoring tiers (200 → 80 pts), aligned with `scoresCalcFactory.ts`
- Add the +500 pt championship winner bonus and keep JSON-LD FAQPage schema populated with the full plain-text answer
- Update both EN and PT-BR translations

## Test plan
- [x] `yarn build` passes
- [x] Unit tests pass (902)
- [x] E2e tests pass (12)
- [ ] Manually verify `/faq` Q5 renders the bulleted tier list in EN and PT-BR


Made with [Cursor](https://cursor.com)