### PR TITLE
Fix results page in-play score calculation

### DIFF
--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -14,6 +14,7 @@ import {
   STATUSES_IN_PLAY,
   STATUSES_FINISHED,
   STATUSES_ERROR,
+  getFixtureResultScores,
 } from "../utils"
 import type { Season, FixtureData, Bet } from "../definitions"
 
@@ -512,6 +513,64 @@ describe("utils", () => {
 
     it("should have correct STATUSES_ERROR", () => {
       expect(STATUSES_ERROR).toEqual(["CANC", "PST", "ABD", "AWD"])
+    })
+  })
+
+  describe("getFixtureResultScores", () => {
+    const baseScore = {
+      halftime: { home: 1, away: 0 },
+      fulltime: { home: 2, away: 1 },
+      extratime: { home: null, away: null },
+      penalty: { home: null, away: null },
+    }
+
+    it("should use fulltime score when match is finished", () => {
+      expect(
+        getFixtureResultScores(
+          { goals: { home: 3, away: 2 }, score: baseScore },
+          "FT"
+        )
+      ).toEqual({ resultHome: 2, resultAway: 1 })
+    })
+
+    it("should prefer live goals when match is in play", () => {
+      expect(
+        getFixtureResultScores(
+          {
+            goals: { home: 3, away: 2 },
+            score: {
+              ...baseScore,
+              halftime: { home: 1, away: 0 },
+              fulltime: { home: null, away: null },
+            },
+          },
+          "2H"
+        )
+      ).toEqual({ resultHome: 3, resultAway: 2 })
+    })
+
+    it("should fall back to halftime when live goals are unavailable", () => {
+      expect(
+        getFixtureResultScores(
+          {
+            goals: { home: null, away: null },
+            score: {
+              ...baseScore,
+              fulltime: { home: null, away: null },
+            },
+          },
+          "HT"
+        )
+      ).toEqual({ resultHome: 1, resultAway: 0 })
+    })
+
+    it("should return zero when match has not started", () => {
+      expect(
+        getFixtureResultScores(
+          { goals: { home: null, away: null }, score: baseScore },
+          "NS"
+        )
+      ).toEqual({ resultHome: 0, resultAway: 0 })
     })
   })
 })

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -226,6 +226,36 @@ export const STATUSES_IN_PLAY = ["1H", "HT", "2H", "ET", "BT", "LIVE"]
 export const STATUSES_FINISHED = ["FT", "AET", "PEN", "CANC", ""]
 export const STATUSES_ERROR = ["CANC", "PST", "ABD", "AWD"]
 
+/** Scores used for bolão point calculation (live goals when in play, fulltime when finished). */
+export function getFixtureResultScores(
+  fixtureData: Pick<FixtureData, "goals" | "score">,
+  statusShort: string
+): { resultHome: number; resultAway: number } {
+  if (STATUSES_FINISHED.includes(statusShort)) {
+    return {
+      resultHome: fixtureData.score.fulltime.home ?? 0,
+      resultAway: fixtureData.score.fulltime.away ?? 0,
+    }
+  }
+
+  if (STATUSES_IN_PLAY.includes(statusShort)) {
+    return {
+      resultHome:
+        fixtureData.goals.home ??
+        fixtureData.score.halftime.home ??
+        fixtureData.score.fulltime.home ??
+        0,
+      resultAway:
+        fixtureData.goals.away ??
+        fixtureData.score.halftime.away ??
+        fixtureData.score.fulltime.away ??
+        0,
+    }
+  }
+
+  return { resultHome: 0, resultAway: 0 }
+}
+
 export const STYLES_TABLE_SHADOW = "shadow-md bg-white p-0 mb-6"
 
 // Session Storage key for the invite bug/fix

--- a/app/ui/bolao/results/__tests__/tableMatchDayResults.test.tsx
+++ b/app/ui/bolao/results/__tests__/tableMatchDayResults.test.tsx
@@ -745,6 +745,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [
         createMockFixture({
+          goals: { home: null, away: null },
           score: {
             halftime: { home: 1, away: 0 },
             fulltime: { home: null, away: null },
@@ -780,6 +781,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [
         createMockFixture({
+          goals: { home: null, away: null },
           score: {
             halftime: { home: null, away: null },
             fulltime: { home: null, away: null },
@@ -808,6 +810,48 @@ describe("TableMatchDayResults", () => {
           resultAway: 0,
         })
       )
+    })
+
+    it("should use live goals when game is in play", () => {
+      vi.mocked(utils.findBetObj).mockImplementation(
+        ({ type }: { type: "home" | "away" }) => {
+          if (type === "home") return { value: 3 } as Bet
+          if (type === "away") return { value: 2 } as Bet
+          return null
+        }
+      )
+
+      const fixtures = [
+        createMockFixture({
+          goals: { home: 3, away: 2 },
+          score: {
+            halftime: { home: null, away: null },
+            fulltime: { home: null, away: null },
+            extratime: { home: null, away: null },
+            penalty: { home: null, away: null },
+          },
+          fixture: {
+            ...createMockFixture().fixture,
+            status: { long: "First Half", short: "1H", elapsed: 25 },
+          },
+        }),
+      ]
+
+      render(
+        <TableMatchDayResults
+          fixtures={fixtures}
+          bets={[createMockBet()]}
+          players={mockPlayers}
+          userId="player1"
+        />
+      )
+
+      expect(scoresCalcFactory.calcScore).toHaveBeenCalledWith({
+        resultHome: 3,
+        resultAway: 2,
+        betHome: 3,
+        betAway: 2,
+      })
     })
   })
 
@@ -1126,7 +1170,7 @@ describe("TableMatchDayResults", () => {
       expect(totalsRow.textContent).toContain("150 pts")
     })
 
-    it("should only count STATUSES_FINISHED, not STATUSES_IN_PLAY", () => {
+    it("should include live scores in totals for in-play fixtures", () => {
       vi.mocked(utils.findBetObj).mockReturnValue({ value: 2 } as Bet)
       vi.mocked(scoresCalcFactory.calcScore).mockReturnValue(100)
 
@@ -1160,9 +1204,8 @@ describe("TableMatchDayResults", () => {
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
       const totalsRow = rows[rows.length - 1]
 
-      // Should show 100 pts in totals (only 1 finished fixture), not 200 pts
-      expect(totalsRow.textContent).toContain("100 pts")
-      expect(totalsRow.textContent).not.toContain("200 pts")
+      // Live in-play fixture + finished fixture (100 pts each)
+      expect(totalsRow.textContent).toContain("200 pts")
     })
 
     it("should calculate totals with multiple finished fixtures", () => {

--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -9,6 +9,7 @@ import {
   STATUSES_IN_PLAY,
   STATUSES_OPEN_TO_PLAY,
   getEmailUsername,
+  getFixtureResultScores,
 } from "@/app/lib/utils"
 import { calcScore } from "@/app/lib/scoresCalcFactory"
 import { StickyTable, Row, Cell } from "react-sticky-table"
@@ -49,39 +50,49 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
   const t = useTranslations("resultsPage")
   const locale = useLocale()
 
-  // Calculate totals per player for finished fixtures only
+  // Totals include finished fixtures and live in-play scores
   const calculatePlayerTotal = (userBolaoId: string): number => {
     let total = 0
 
     fixtures.forEach((fixtureData) => {
-      if (STATUSES_FINISHED.includes(fixtureData.fixture.status.short)) {
-        const homeBetObj = findBetObj({
-          bets,
-          fixtureId: fixtureData.fixture.id.toString(),
-          type: "home",
-          userBolaoId,
+      const statusShort = fixtureData.fixture.status.short
+      const scoresVisible =
+        STATUSES_IN_PLAY.includes(statusShort) ||
+        STATUSES_FINISHED.includes(statusShort)
+
+      if (!scoresVisible) return
+
+      const homeBetObj = findBetObj({
+        bets,
+        fixtureId: fixtureData.fixture.id.toString(),
+        type: "home",
+        userBolaoId,
+      })
+
+      const awayBetObj = findBetObj({
+        bets,
+        fixtureId: fixtureData.fixture.id.toString(),
+        type: "away",
+        userBolaoId,
+      })
+
+      if (
+        homeBetObj?.value !== undefined &&
+        awayBetObj?.value !== undefined
+      ) {
+        const { resultHome, resultAway } = getFixtureResultScores(
+          fixtureData,
+          statusShort
+        )
+
+        const fixtureScore = calcScore({
+          resultHome,
+          resultAway,
+          betHome: homeBetObj.value,
+          betAway: awayBetObj.value,
         })
 
-        const awayBetObj = findBetObj({
-          bets,
-          fixtureId: fixtureData.fixture.id.toString(),
-          type: "away",
-          userBolaoId,
-        })
-
-        if (
-          homeBetObj?.value !== undefined &&
-          awayBetObj?.value !== undefined
-        ) {
-          const fixtureScore = calcScore({
-            resultHome: fixtureData.score.fulltime.home || 0,
-            resultAway: fixtureData.score.fulltime.away || 0,
-            betHome: homeBetObj.value,
-            betAway: awayBetObj.value,
-          })
-
-          total = total + fixtureScore
-        }
+        total = total + fixtureScore
       }
     })
 
@@ -205,12 +216,12 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
 
                       let score = 0
                       if (canShowScores) {
-                        const fulltime = fixtureData.score.fulltime
-                        const halftime = fixtureData.score.halftime
+                        const { resultHome, resultAway } =
+                          getFixtureResultScores(fixtureData, statusShort)
 
                         score = calcScore({
-                          resultHome: fulltime.home || halftime.home || 0,
-                          resultAway: fulltime.away || halftime.away || 0,
+                          resultHome,
+                          resultAway,
                           betHome: Number(betHome),
                           betAway: Number(betAway),
                         })


### PR DESCRIPTION
## Summary
- Add `getFixtureResultScores()` to derive bolão scoring inputs from live `goals` during in-play matches (with halftime/fulltime fallbacks), instead of only halftime or fulltime fields.
- Update the results table to use that helper for per-match points and round totals, so scores reflect the current match state when the page loads.
- Add unit tests covering live goals, halftime fallback, and in-play totals.

## Test plan
- [x] `yarn test app/lib/__tests__/utils.test.ts app/ui/bolao/results/__tests__/tableMatchDayResults.test.tsx`
- [ ] Open a bolão results page during a live match and confirm per-match points match the displayed score
- [ ] Confirm round totals include in-play fixtures on page load
- [ ] Confirm finished matches still use fulltime scores


Made with [Cursor](https://cursor.com)