### PR TITLE
Fix pt-BR label for results nav link.

### DIFF
--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -139,7 +139,7 @@
   "bolaoLinks": {
     "bet": "APOSTA",
     "standings": "TABELA",
-    "results": "PLACAR",
+    "results": "RESULTADOS",
     "lead": "RANKING"
   },
   "betPage": {


### PR DESCRIPTION
Use "RESULTADOS" instead of "PLACAR" to match the results page naming.