### PR TITLE
fix(bet): enforce server-side bet locks and reliable save UX

### DIFF
--- a/app/__tests__/bolao/[id]/results/page.test.tsx
+++ b/app/__tests__/bolao/[id]/results/page.test.tsx
@@ -54,7 +54,13 @@ describe("ResultsPage", () => {
             bolao: { id: "bolao-123", year: 2023, competition_id: "comp-1" },
             currentRound: "Round 1",
             allRounds: ["Round 1", "Round 2"],
-            fixtures: [{ league: { logo: "logo.png", name: "League Name" } }],
+            fixtures: [{
+                fixture: { id: 1, status: { short: "NS" }, timestamp: 1, date: new Date() },
+                league: { logo: "logo.png", name: "League Name", round: "Round 1" },
+                teams: { home: { logo: "", name: "A" }, away: { logo: "", name: "B" } },
+                goals: { home: null, away: null },
+                score: { halftime: { home: null, away: null }, fulltime: { home: null, away: null }, extratime: { home: null, away: null }, penalty: { home: null, away: null } },
+            }],
             isLastRound: false,
             isFirstRound: true,
             bets: [],
@@ -79,6 +85,8 @@ describe("ResultsPage", () => {
 
         const table = screen.getByTestId("table-match-day-results")
         const tableProps = JSON.parse(table.getAttribute("data-props") || "{}")
-        expect(tableProps.userId).toBe("user-123")
+        expect(tableProps.tableView).toBeDefined()
+        expect(tableProps.tableView.players).toEqual([])
+        expect(tableProps.userId).toBeUndefined()
     })
 })

--- a/app/bolao/[id]/results/page.tsx
+++ b/app/bolao/[id]/results/page.tsx
@@ -1,4 +1,5 @@
 import { getData } from "@/app/lib/controllerResults"
+import { buildResultsTableView } from "@/app/lib/resultsTableData"
 import { auth } from "@clerk/nextjs/server"
 import BolaoPageTitle from "@/app/ui/bolao/bolaoPageTitle"
 import BolaoLinks from "@/app/ui/bolao/bolaoLinks"
@@ -34,6 +35,13 @@ async function ResultsPage(props: {
       (el: string) => el.toLowerCase() === data.currentRound.toLowerCase()
     ) + 1
 
+  const tableView = buildResultsTableView({
+    fixtures: data.fixtures,
+    bets: data.bets,
+    players: data.players,
+    currentUserId: userId,
+  })
+
   return (
     <main>
       <BolaoPageTitle
@@ -51,12 +59,7 @@ async function ResultsPage(props: {
         currentRoundName={data.currentRound}
       />
 
-      <TableMatchDayResults
-        bets={data.bets}
-        fixtures={data.fixtures}
-        players={data.players}
-        userId={userId}
-      />
+      <TableMatchDayResults tableView={tableView} />
     </main>
   )
 }

--- a/app/lib/__tests__/actions.test.ts
+++ b/app/lib/__tests__/actions.test.ts
@@ -27,6 +27,11 @@ vi.mock("../data", () => ({
   fetchFixtures: vi.fn(),
 }))
 
+// Mock auth role
+vi.mock("../authRole", () => ({
+  getUserRole: vi.fn(),
+}))
+
 // Mock utils
 vi.mock("../utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../utils")>()
@@ -55,6 +60,37 @@ import { revalidatePath } from "next/cache"
 import { auth } from "@clerk/nextjs/server"
 import { fetchLeague, fetchBolao, fetchFixtures } from "../data"
 import { getCurrentSeasonObject } from "../utils"
+import { getUserRole } from "../authRole"
+
+const FIXTURE_ID = "12345"
+
+function mockOpenFixture() {
+  return {
+    fixture: {
+      id: Number(FIXTURE_ID),
+      status: { short: "NS" },
+      timestamp: Math.floor(Date.now() / 1000) + 3600,
+      date: new Date(Date.now() + 3_600_000),
+    },
+  }
+}
+
+function mockBetAccessChecks(userId = "user-1") {
+  vi.mocked(auth).mockResolvedValue({ userId } as any)
+  vi.mocked(getUserRole).mockResolvedValue("user")
+  vi.mocked(fetchBolao).mockResolvedValue({
+    id: "bolao-1",
+    competition_id: "1",
+    year: 2026,
+  } as any)
+  vi.mocked(fetchFixtures).mockResolvedValue([mockOpenFixture()] as any)
+}
+
+function mockUserBolaoOwnership(userId = "user-1") {
+  return {
+    rows: [{ bolao_id: "bolao-1", user_id: userId }],
+  }
+}
 
 describe("actions", () => {
   beforeEach(() => {
@@ -345,29 +381,36 @@ describe("actions", () => {
   })
 
   describe("createBet", () => {
+    beforeEach(() => {
+      mockBetAccessChecks()
+    })
+
     it("should create a bet successfully", async () => {
       const mockBet = {
         id: "bet-1",
         user_bolao_id: "ub-1",
-        fixture_id: "fixture-1",
+        fixture_id: FIXTURE_ID,
         value: 2,
         type: "home",
       }
 
-      vi.mocked(sql).mockResolvedValue({ rows: [mockBet] } as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockResolvedValueOnce({ rows: [mockBet] } as any)
 
       const result = await createBet({
         userBolaoId: "ub-1",
-        fixtureId: "fixture-1",
+        fixtureId: FIXTURE_ID,
         value: 2,
         type: "home",
       })
 
-      expect(sql).toHaveBeenCalled()
-      const [strings, userBolaoId, fixtureId, value, type] = vi.mocked(sql).mock.calls[0]
-      expect(strings.join("")).toContain("INSERT INTO bets")
+      expect(sql).toHaveBeenCalledTimes(2)
+      const [insertStrings, userBolaoId, fixtureId, value, type] =
+        vi.mocked(sql).mock.calls[1]
+      expect(insertStrings.join("")).toContain("INSERT INTO bets")
       expect(userBolaoId).toBe("ub-1")
-      expect(fixtureId).toBe("fixture-1")
+      expect(fixtureId).toBe(FIXTURE_ID)
       expect(value).toBe(2)
       expect(type).toBe("home")
       expect(result).toEqual(mockBet)
@@ -377,16 +420,18 @@ describe("actions", () => {
       const mockBet = {
         id: "bet-1",
         user_bolao_id: "ub-1",
-        fixture_id: "fixture-1",
+        fixture_id: FIXTURE_ID,
         value: 1,
         type: "away",
       }
 
-      vi.mocked(sql).mockResolvedValue({ rows: [mockBet] } as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockResolvedValueOnce({ rows: [mockBet] } as any)
 
       const result = await createBet({
         userBolaoId: "ub-1",
-        fixtureId: "fixture-1",
+        fixtureId: FIXTURE_ID,
         value: 1,
         type: "away",
       })
@@ -394,12 +439,74 @@ describe("actions", () => {
       expect(result).toEqual(mockBet)
     })
 
-    it("should handle database errors", async () => {
-      vi.mocked(sql).mockRejectedValue(new Error("Database error"))
+    it("rejects unauthenticated requests", async () => {
+      vi.mocked(auth).mockResolvedValue({ userId: null } as any)
 
       const result = await createBet({
         userBolaoId: "ub-1",
-        fixtureId: "fixture-1",
+        fixtureId: FIXTURE_ID,
+        value: 2,
+        type: "home",
+      })
+
+      expect(result).toEqual({ success: false, message: "Unauthorized." })
+      expect(sql).not.toHaveBeenCalled()
+    })
+
+    it("rejects bets for another user's bolao", async () => {
+      vi.mocked(sql).mockResolvedValueOnce(
+        mockUserBolaoOwnership("other-user") as any
+      )
+
+      const result = await createBet({
+        userBolaoId: "ub-1",
+        fixtureId: FIXTURE_ID,
+        value: 2,
+        type: "home",
+      })
+
+      expect(result).toEqual({ success: false, message: "Forbidden." })
+      expect(sql).toHaveBeenCalledTimes(1)
+    })
+
+    it("rejects bets after kickoff", async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-15T20:00:00Z"))
+      vi.mocked(fetchFixtures).mockResolvedValue([
+        {
+          fixture: {
+            id: Number(FIXTURE_ID),
+            status: { short: "NS" },
+            timestamp: Math.floor(new Date("2026-06-15T19:00:00Z").getTime() / 1000),
+            date: new Date("2026-06-15T19:00:00Z"),
+          },
+        },
+      ] as any)
+      vi.mocked(sql).mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+
+      const result = await createBet({
+        userBolaoId: "ub-1",
+        fixtureId: FIXTURE_ID,
+        value: 2,
+        type: "home",
+      })
+
+      expect(result).toEqual({
+        success: false,
+        message: "Betting is locked for this fixture.",
+      })
+      expect(sql).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it("should handle database errors", async () => {
+      vi.mocked(sql)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockRejectedValueOnce(new Error("Database error"))
+
+      const result = await createBet({
+        userBolaoId: "ub-1",
+        fixtureId: FIXTURE_ID,
         value: 2,
         type: "home",
       })
@@ -411,29 +518,93 @@ describe("actions", () => {
   })
 
   describe("updateBet", () => {
+    beforeEach(() => {
+      mockBetAccessChecks()
+    })
+
     it("should update a bet successfully", async () => {
       const mockBet = {
         id: "bet-1",
         value: 3,
       }
 
-      vi.mocked(sql).mockResolvedValue({ rows: [mockBet] } as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              fixture_id: FIXTURE_ID,
+              user_bolao_id: "ub-1",
+              user_id: "user-1",
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockResolvedValueOnce({ rows: [mockBet] } as any)
 
       const result = await updateBet({
         betId: "bet-1",
         value: 3,
       })
 
-      expect(sql).toHaveBeenCalled()
-      const [strings, value, betId] = vi.mocked(sql).mock.calls[0]
+      expect(sql).toHaveBeenCalledTimes(3)
+      const [strings, value, betId] = vi.mocked(sql).mock.calls[2]
       expect(strings.join("")).toContain("UPDATE bets")
       expect(value).toBe(3)
       expect(betId).toBe("bet-1")
       expect(result).toEqual(mockBet)
     })
 
+    it("rejects updates after the fixture has started", async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-15T20:00:00Z"))
+      vi.mocked(fetchFixtures).mockResolvedValue([
+        {
+          fixture: {
+            id: Number(FIXTURE_ID),
+            status: { short: "1H" },
+            timestamp: Math.floor(new Date("2026-06-15T19:00:00Z").getTime() / 1000),
+            date: new Date("2026-06-15T19:00:00Z"),
+          },
+        },
+      ] as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              fixture_id: FIXTURE_ID,
+              user_bolao_id: "ub-1",
+              user_id: "user-1",
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+
+      const result = await updateBet({
+        betId: "bet-1",
+        value: 3,
+      })
+
+      expect(result).toEqual({
+        success: false,
+        message: "Betting is locked for this fixture.",
+      })
+      expect(sql).toHaveBeenCalledTimes(2)
+      vi.useRealTimers()
+    })
+
     it("should handle database errors", async () => {
-      vi.mocked(sql).mockRejectedValue(new Error("Database error"))
+      vi.mocked(sql)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              fixture_id: FIXTURE_ID,
+              user_bolao_id: "ub-1",
+              user_id: "user-1",
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockRejectedValueOnce(new Error("Database error"))
 
       const result = await updateBet({
         betId: "bet-1",
@@ -514,21 +685,47 @@ describe("actions", () => {
   })
 
   describe("deleteBet", () => {
+    beforeEach(() => {
+      mockBetAccessChecks()
+    })
+
     it("should delete a bet successfully", async () => {
       const mockData = [{ id: "bet-1" }]
-      vi.mocked(sql).mockResolvedValue({ rows: mockData } as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              fixture_id: FIXTURE_ID,
+              user_bolao_id: "ub-1",
+              user_id: "user-1",
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockResolvedValueOnce({ rows: mockData } as any)
 
       const result = await deleteBet("bet-1")
 
-      expect(sql).toHaveBeenCalled()
-      const [strings, betId] = vi.mocked(sql).mock.calls[0]
+      expect(sql).toHaveBeenCalledTimes(3)
+      const [strings, betId] = vi.mocked(sql).mock.calls[2]
       expect(strings.join("")).toContain("DELETE FROM bets")
       expect(betId).toBe("bet-1")
       expect(result).toEqual(mockData)
     })
 
     it("should handle database errors", async () => {
-      vi.mocked(sql).mockRejectedValue(new Error("Database error"))
+      vi.mocked(sql)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              fixture_id: FIXTURE_ID,
+              user_bolao_id: "ub-1",
+              user_id: "user-1",
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockRejectedValueOnce(new Error("Database error"))
 
       const result = await deleteBet("bet-1")
 
@@ -572,14 +769,18 @@ describe("actions", () => {
     })
 
     it("should handle multiple bet operations", async () => {
+      mockBetAccessChecks()
+
       // Create bet
-      vi.mocked(sql).mockResolvedValueOnce({
-        rows: [{ id: "bet-1", value: 2 }],
-      } as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockResolvedValueOnce({
+          rows: [{ id: "bet-1", value: 2 }],
+        } as any)
 
       const createResult = await createBet({
         userBolaoId: "ub-1",
-        fixtureId: "fixture-1",
+        fixtureId: FIXTURE_ID,
         value: 2,
         type: "home",
       })
@@ -587,9 +788,20 @@ describe("actions", () => {
       expect(createResult).toHaveProperty("id", "bet-1")
 
       // Update bet
-      vi.mocked(sql).mockResolvedValueOnce({
-        rows: [{ id: "bet-1", value: 3 }],
-      } as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              fixture_id: FIXTURE_ID,
+              user_bolao_id: "ub-1",
+              user_id: "user-1",
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockResolvedValueOnce({
+          rows: [{ id: "bet-1", value: 3 }],
+        } as any)
 
       const updateResult = await updateBet({
         betId: "bet-1",
@@ -599,9 +811,20 @@ describe("actions", () => {
       expect(updateResult).toHaveProperty("value", 3)
 
       // Delete bet
-      vi.mocked(sql).mockResolvedValueOnce({
-        rows: [{ id: "bet-1" }],
-      } as any)
+      vi.mocked(sql)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              fixture_id: FIXTURE_ID,
+              user_bolao_id: "ub-1",
+              user_id: "user-1",
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce(mockUserBolaoOwnership() as any)
+        .mockResolvedValueOnce({
+          rows: [{ id: "bet-1" }],
+        } as any)
 
       const deleteResult = await deleteBet("bet-1")
 

--- a/app/lib/__tests__/resultsTableData.test.ts
+++ b/app/lib/__tests__/resultsTableData.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest"
+import { buildResultsTableView } from "../resultsTableData"
+import type { Bet, FixtureData, PlayersData } from "../definitions"
+
+const mockPlayers: PlayersData[] = [
+  {
+    id: "player1",
+    username: "johnny",
+    email: "john@example.com",
+    userBolaoId: "ub-1",
+  },
+  {
+    id: "player2",
+    username: null,
+    email: "jane@example.com",
+    userBolaoId: "ub-2",
+  },
+]
+
+const createFixture = (statusShort: string): FixtureData =>
+  ({
+    fixture: {
+      id: 12345,
+      status: { short: statusShort, long: statusShort, elapsed: 0 },
+      timestamp: 1705348800,
+      date: new Date("2024-01-15T20:00:00Z"),
+    },
+    league: { round: "Group Stage - 1" },
+    teams: {
+      home: { id: 1, name: "Home", logo: "h.png" },
+      away: { id: 2, name: "Away", logo: "a.png" },
+    },
+    goals: { home: 2, away: 1 },
+    score: {
+      halftime: { home: 1, away: 0 },
+      fulltime: { home: 2, away: 1 },
+      extratime: { home: null, away: null },
+      penalty: { home: null, away: null },
+    },
+  }) as FixtureData
+
+describe("buildResultsTableView", () => {
+  it("does not expose emails or internal ids in the view model", () => {
+    const view = buildResultsTableView({
+      fixtures: [createFixture("NS")],
+      bets: [],
+      players: mockPlayers,
+      currentUserId: "player1",
+    })
+
+    const serialized = JSON.stringify(view)
+    expect(serialized).not.toContain("john@example.com")
+    expect(serialized).not.toContain("jane@example.com")
+    expect(serialized).not.toContain("ub-1")
+    expect(serialized).not.toContain("ub-2")
+    expect(serialized).not.toContain("player1")
+    expect(serialized).not.toContain("player2")
+  })
+
+  it("uses username or email prefix for display names", () => {
+    const view = buildResultsTableView({
+      fixtures: [createFixture("FT")],
+      bets: [],
+      players: mockPlayers,
+      currentUserId: "player1",
+    })
+
+    expect(view.players[0].displayName).toBe("johnny")
+    expect(view.players[1].displayName).toBe("jane")
+  })
+
+  it("hides other players bets before kickoff", () => {
+    const bets: Bet[] = [
+      {
+        id: "bet-1",
+        user_bolao_id: "ub-1",
+        fixture_id: "12345",
+        value: 2,
+        type: "home",
+      },
+      {
+        id: "bet-2",
+        user_bolao_id: "ub-1",
+        fixture_id: "12345",
+        value: 1,
+        type: "away",
+      },
+      {
+        id: "bet-3",
+        user_bolao_id: "ub-2",
+        fixture_id: "12345",
+        value: 0,
+        type: "home",
+      },
+      {
+        id: "bet-4",
+        user_bolao_id: "ub-2",
+        fixture_id: "12345",
+        value: 0,
+        type: "away",
+      },
+    ]
+
+    const view = buildResultsTableView({
+      fixtures: [createFixture("NS")],
+      bets,
+      players: mockPlayers,
+      currentUserId: "player1",
+    })
+
+    expect(view.rows[0].cells[0]).toEqual({
+      home: "2",
+      away: "1",
+      points: null,
+    })
+    expect(view.rows[0].cells[1]).toEqual({
+      home: ".",
+      away: ".",
+      points: null,
+    })
+  })
+
+  it("shows all bets once the fixture is in play", () => {
+    const bets: Bet[] = [
+      {
+        id: "bet-1",
+        user_bolao_id: "ub-2",
+        fixture_id: "12345",
+        value: 1,
+        type: "home",
+      },
+      {
+        id: "bet-2",
+        user_bolao_id: "ub-2",
+        fixture_id: "12345",
+        value: 0,
+        type: "away",
+      },
+    ]
+
+    const view = buildResultsTableView({
+      fixtures: [createFixture("1H")],
+      bets,
+      players: mockPlayers,
+      currentUserId: "player1",
+    })
+
+    expect(view.rows[0].cells[1].home).toBe("1")
+    expect(view.rows[0].cells[1].away).toBe("0")
+    expect(view.rows[0].cells[1].points).not.toBeNull()
+  })
+})

--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 import {
   getCurrentSeasonObject,
   sortFixtures,
@@ -15,6 +15,7 @@ import {
   STATUSES_FINISHED,
   STATUSES_ERROR,
   getFixtureResultScores,
+  isFixtureOpenToBet,
 } from "../utils"
 import type { Season, FixtureData, Bet } from "../definitions"
 
@@ -491,6 +492,47 @@ describe("utils", () => {
 
     it("should handle email with underscores", () => {
       expect(getEmailUsername("user_name@example.com")).toBe("user_name")
+    })
+  })
+
+  describe("isFixtureOpenToBet", () => {
+    const baseFixture = {
+      fixture: {
+        id: 1,
+        status: { short: "NS", long: "Not Started", elapsed: 0 },
+        timestamp: Math.floor(new Date("2026-06-15T19:00:00Z").getTime() / 1000),
+        date: new Date("2026-06-15T19:00:00Z"),
+      },
+    } as any
+
+    it("returns true before kickoff for open statuses", () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-15T18:00:00Z"))
+
+      expect(isFixtureOpenToBet(baseFixture)).toBe(true)
+
+      vi.useRealTimers()
+    })
+
+    it("returns false after kickoff even if status is still NS", () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-06-15T20:00:00Z"))
+
+      expect(isFixtureOpenToBet(baseFixture)).toBe(false)
+
+      vi.useRealTimers()
+    })
+
+    it("returns false when fixture is in play", () => {
+      expect(
+        isFixtureOpenToBet({
+          ...baseFixture,
+          fixture: {
+            ...baseFixture.fixture,
+            status: { short: "1H", long: "First Half", elapsed: 10 },
+          },
+        })
+      ).toBe(false)
     })
   })
 

--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -5,7 +5,12 @@ import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
 import { auth } from "@clerk/nextjs/server"
 import { fetchLeague, fetchBolao, fetchFixtures } from "./data"
-import { getCurrentSeasonObject, isChampionPickLocked } from "./utils"
+import { getUserRole } from "./authRole"
+import {
+  getCurrentSeasonObject,
+  isChampionPickLocked,
+  isFixtureOpenToBet,
+} from "./utils"
 import {
   BetResult,
   UpdateBolaoResult,
@@ -152,6 +157,110 @@ export async function createUserBolao(
   }
 }
 
+type BetMutationError = { success: false; message: string }
+
+type BetMutationContext =
+  | BetMutationError
+  | {
+      userId: string
+      userBolaoId: string
+      fixtureId: string
+    }
+
+function isBetMutationError(
+  context: BetMutationContext
+): context is BetMutationError {
+  return "success" in context && context.success === false
+}
+
+async function assertCanMutateBet({
+  userId,
+  userBolaoId,
+  fixtureId,
+}: {
+  userId: string
+  userBolaoId: string
+  fixtureId: string
+}): Promise<BetMutationError | null> {
+  const isAdmin = (await getUserRole(userId)) === "admin"
+
+  const ownership = await sql`
+    SELECT ub.bolao_id, ub.user_id
+    FROM user_bolao ub
+    WHERE CAST(ub.id AS VARCHAR) = ${userBolaoId}
+  `
+  const row = ownership.rows[0]
+
+  if (!row) {
+    return { success: false, message: "Forbidden." }
+  }
+
+  if (String(row.user_id) !== userId && !isAdmin) {
+    return { success: false, message: "Forbidden." }
+  }
+
+  if (isAdmin) {
+    return null
+  }
+
+  const bolao = await fetchBolao(String(row.bolao_id))
+  const fixtures = await fetchFixtures({
+    leagueId: bolao.competition_id,
+    year: bolao.year,
+  })
+  const fixture = fixtures.find(
+    (entry) => entry.fixture.id.toString() === fixtureId
+  )
+
+  if (!fixture) {
+    return { success: false, message: "Fixture not found." }
+  }
+
+  if (!isFixtureOpenToBet(fixture)) {
+    return { success: false, message: "Betting is locked for this fixture." }
+  }
+
+  return null
+}
+
+async function getBetMutationContext(
+  betId: string
+): Promise<BetMutationContext> {
+  const { userId } = await auth()
+
+  if (!userId) {
+    return { success: false, message: "Unauthorized." }
+  }
+
+  const betLookup = await sql`
+    SELECT b.fixture_id, b.user_bolao_id, ub.user_id
+    FROM bets b
+    INNER JOIN user_bolao ub ON CAST(b.user_bolao_id AS VARCHAR) = CAST(ub.id AS VARCHAR)
+    WHERE CAST(b.id AS VARCHAR) = ${betId}
+  `
+  const row = betLookup.rows[0]
+
+  if (!row) {
+    return { success: false, message: "Bet not found." }
+  }
+
+  const validation = await assertCanMutateBet({
+    userId,
+    userBolaoId: String(row.user_bolao_id),
+    fixtureId: String(row.fixture_id),
+  })
+
+  if (validation) {
+    return validation
+  }
+
+  return {
+    userId,
+    userBolaoId: String(row.user_bolao_id),
+    fixtureId: String(row.fixture_id),
+  }
+}
+
 export async function createBet({
   userBolaoId,
   fixtureId,
@@ -163,7 +272,23 @@ export async function createBet({
   value: number
   type: "away" | "home"
 }) {
+  const { userId } = await auth()
+
+  if (!userId) {
+    return { success: false, message: "Unauthorized." } as BetResult
+  }
+
   try {
+    const validation = await assertCanMutateBet({
+      userId,
+      userBolaoId,
+      fixtureId,
+    })
+
+    if (validation) {
+      return validation as BetResult
+    }
+
     const result = await sql`
         INSERT INTO bets (user_bolao_id, fixture_id, value, type)
         VALUES (${userBolaoId}, ${fixtureId}, ${value}, ${type})
@@ -188,6 +313,12 @@ export async function updateBet({
   betId: string
 }) {
   try {
+    const context = await getBetMutationContext(betId)
+
+    if (isBetMutationError(context)) {
+      return context as BetResult
+    }
+
     const result = await sql`
         UPDATE bets
         SET value = ${value}
@@ -310,6 +441,12 @@ export async function deleteUserBolao(userBolaoId: string) {
 
 export async function deleteBet(betId: string) {
   try {
+    const context = await getBetMutationContext(betId)
+
+    if (isBetMutationError(context)) {
+      return context
+    }
+
     const result = await sql`
       DELETE FROM bets
       WHERE CAST(id AS VARCHAR) = ${betId}

--- a/app/lib/actions.ts
+++ b/app/lib/actions.ts
@@ -18,6 +18,7 @@ import {
   CreateBolaoResult,
   ChampionPickResult,
   ChampionPick,
+  FixtureData,
 } from "./definitions"
 
 export async function createUser({ id, role }: { id: string; role: string }) {
@@ -209,7 +210,7 @@ async function assertCanMutateBet({
     year: bolao.year,
   })
   const fixture = fixtures.find(
-    (entry) => entry.fixture.id.toString() === fixtureId
+    (entry: FixtureData) => entry.fixture.id.toString() === fixtureId
   )
 
   if (!fixture) {

--- a/app/lib/resultsTableData.ts
+++ b/app/lib/resultsTableData.ts
@@ -1,0 +1,173 @@
+import { Bet, FixtureData, PlayersData } from "./definitions"
+import { calcScore } from "./scoresCalcFactory"
+import {
+  findBetObj,
+  getEmailUsername,
+  getFixtureResultScores,
+  INITIAL_BET_VALUE,
+  STATUSES_FINISHED,
+  STATUSES_IN_PLAY,
+} from "./utils"
+
+export type ResultsPlayerColumn = {
+  displayName: string
+  isCurrentUser: boolean
+}
+
+export type ResultsBetCell = {
+  home: string
+  away: string
+  points: number | null
+}
+
+export type ResultsFixtureRow = {
+  fixture: FixtureData
+  cells: ResultsBetCell[]
+}
+
+export type ResultsTableView = {
+  players: ResultsPlayerColumn[]
+  rows: ResultsFixtureRow[]
+  totals: number[]
+}
+
+function calculatePlayerTotal({
+  fixtures,
+  bets,
+  userBolaoId,
+}: {
+  fixtures: FixtureData[]
+  bets: Bet[]
+  userBolaoId: string
+}): number {
+  let total = 0
+
+  fixtures.forEach((fixtureData) => {
+    const statusShort = fixtureData.fixture.status.short
+    const scoresVisible =
+      STATUSES_IN_PLAY.includes(statusShort) ||
+      STATUSES_FINISHED.includes(statusShort)
+
+    if (!scoresVisible) return
+
+    const homeBetObj = findBetObj({
+      bets,
+      fixtureId: fixtureData.fixture.id.toString(),
+      type: "home",
+      userBolaoId,
+    })
+
+    const awayBetObj = findBetObj({
+      bets,
+      fixtureId: fixtureData.fixture.id.toString(),
+      type: "away",
+      userBolaoId,
+    })
+
+    if (homeBetObj?.value !== undefined && awayBetObj?.value !== undefined) {
+      const { resultHome, resultAway } = getFixtureResultScores(
+        fixtureData,
+        statusShort
+      )
+
+      total += calcScore({
+        resultHome,
+        resultAway,
+        betHome: homeBetObj.value,
+        betAway: awayBetObj.value,
+      })
+    }
+  })
+
+  return total
+}
+
+export function buildResultsTableView({
+  fixtures,
+  bets,
+  players,
+  currentUserId,
+}: {
+  fixtures: FixtureData[]
+  bets: Bet[]
+  players: PlayersData[]
+  currentUserId: string
+}): ResultsTableView {
+  const playerColumns: ResultsPlayerColumn[] = players.map((player) => ({
+    displayName: player.username || getEmailUsername(player.email),
+    isCurrentUser: player.id === currentUserId,
+  }))
+
+  const rows: ResultsFixtureRow[] = fixtures.map((fixtureData) => {
+    const statusShort = fixtureData.fixture.status.short
+    const canShowScores =
+      STATUSES_IN_PLAY.includes(statusShort) ||
+      STATUSES_FINISHED.includes(statusShort)
+
+    const cells: ResultsBetCell[] = players.map((player) => {
+      const showScores = player.id === currentUserId || canShowScores
+
+      const homeBetObj = findBetObj({
+        bets,
+        fixtureId: fixtureData.fixture.id.toString(),
+        type: "home",
+        userBolaoId: player.userBolaoId,
+      })
+
+      const awayBetObj = findBetObj({
+        bets,
+        fixtureId: fixtureData.fixture.id.toString(),
+        type: "away",
+        userBolaoId: player.userBolaoId,
+      })
+
+      const betHome = homeBetObj
+        ? homeBetObj.value.toString()
+        : INITIAL_BET_VALUE
+      const betAway = awayBetObj
+        ? awayBetObj.value.toString()
+        : INITIAL_BET_VALUE
+
+      let points: number | null = null
+      if (
+        canShowScores &&
+        homeBetObj?.value !== undefined &&
+        awayBetObj?.value !== undefined
+      ) {
+        const { resultHome, resultAway } = getFixtureResultScores(
+          fixtureData,
+          statusShort
+        )
+
+        points = calcScore({
+          resultHome,
+          resultAway,
+          betHome: homeBetObj.value,
+          betAway: awayBetObj.value,
+        })
+      }
+
+      return {
+        home: showScores ? betHome : INITIAL_BET_VALUE,
+        away: showScores ? betAway : INITIAL_BET_VALUE,
+        points,
+      }
+    })
+
+    return { fixture: fixtureData, cells }
+  })
+
+  const totals = players.map((player) =>
+    calculatePlayerTotal({
+      fixtures,
+      bets,
+      userBolaoId: player.userBolaoId,
+    })
+  )
+
+  return {
+    players: playerColumns,
+    rows,
+    totals,
+  }
+}

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -223,6 +223,16 @@ export const getEmailUsername = (email: string): string => {
 // api-football.com/documentation-v3#tag/Fixtures/operation/get-fixtures-rounds
 export const STATUSES_OPEN_TO_PLAY = ["TBD", "NS", "PST", "AWD"]
 export const STATUSES_IN_PLAY = ["1H", "HT", "2H", "ET", "BT", "LIVE"]
+
+/** Whether non-admin players may create or change bets for this fixture. */
+export function isFixtureOpenToBet(fixture: FixtureData): boolean {
+  if (!STATUSES_OPEN_TO_PLAY.includes(fixture.fixture.status.short)) {
+    return false
+  }
+
+  const kickoffMs = getFixtureTimestamp(fixture.fixture) * 1000
+  return Date.now() < kickoffMs
+}
 export const STATUSES_FINISHED = ["FT", "AET", "PEN", "CANC", ""]
 export const STATUSES_ERROR = ["CANC", "PST", "ABD", "AWD"]
 

--- a/app/ui/bolao/bet/__tests__/buttonsBet.test.tsx
+++ b/app/ui/bolao/bet/__tests__/buttonsBet.test.tsx
@@ -10,6 +10,16 @@ vi.mock("@/app/lib/actions", () => ({
   updateBet: vi.fn(),
 }))
 
+const mockToast = vi.fn()
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
 describe("ButtonsBet", () => {
   const defaultProps = {
     userBolaoId: "user-bolao-123",
@@ -20,6 +30,7 @@ describe("ButtonsBet", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockToast.mockClear()
   })
 
   afterEach(() => {
@@ -421,16 +432,20 @@ describe("ButtonsBet", () => {
 
       await user.click(incrementButton)
 
-      // Wait for debounce
       await waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "Error creating/updating bet:",
           expect.any(Error)
         )
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: "destructive",
+            title: "saveErrorTitle",
+          })
+        )
       })
 
-      // Component should still be functional
-      expect(screen.getByText("0")).toBeInTheDocument()
+      expect(screen.getByText(".")).toBeInTheDocument()
 
       consoleErrorSpy.mockRestore()
     })
@@ -451,12 +466,45 @@ describe("ButtonsBet", () => {
 
       await user.click(incrementButton)
 
-      // Wait for debounce
       await waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalled()
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: "destructive",
+            title: "saveErrorTitle",
+          })
+        )
       })
 
+      expect(screen.getByText("3")).toBeInTheDocument()
+
       consoleErrorSpy.mockRestore()
+    })
+
+    it("reverts and shows toast when server rejects the save", async () => {
+      const user = userEvent.setup()
+      const mockCreateBet = vi.mocked(actions.createBet)
+      mockCreateBet.mockResolvedValue({
+        success: false,
+        message: "Betting is locked for this fixture.",
+      })
+
+      render(<ButtonsBet {...defaultProps} />)
+
+      const buttons = screen.getAllByRole("button")
+      await user.click(buttons[1])
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: "destructive",
+            title: "saveErrorTitle",
+            description: "saveLockedDescription",
+          })
+        )
+      })
+
+      expect(screen.getByText(".")).toBeInTheDocument()
     })
   })
 
@@ -546,22 +594,12 @@ describe("ButtonsBet", () => {
       const mockCreateBet = vi.mocked(actions.createBet)
       const mockUpdateBet = vi.mocked(actions.updateBet)
 
-      // Simulate slow createBet response
+      let resolveCreate: (value: unknown) => void = () => {}
       mockCreateBet.mockImplementation(
         () =>
-          new Promise((resolve) =>
-            setTimeout(
-              () =>
-                resolve({
-                  id: "new-bet-456",
-                  user_bolao_id: "user-bolao-123",
-                  fixture_id: "fixture-456",
-                  value: 1,
-                  type: "home",
-                }),
-              100
-            )
-          )
+          new Promise((resolve) => {
+            resolveCreate = resolve
+          })
       )
 
       mockUpdateBet.mockResolvedValue({
@@ -577,31 +615,68 @@ describe("ButtonsBet", () => {
       const buttons = screen.getAllByRole("button")
       const incrementButton = buttons[1]
 
-      // Click to 1, then quickly to 2 before debounce completes
       await user.click(incrementButton)
       await user.click(incrementButton)
 
-      // Wait for createBet (first value)
-      await waitFor(
-        () => {
-          expect(mockCreateBet).toHaveBeenCalledTimes(1)
-        },
-        { timeout: 2000 }
-      )
+      await waitFor(() => {
+        expect(mockCreateBet).toHaveBeenCalledWith({
+          userBolaoId: "user-bolao-123",
+          value: 1,
+          type: "home",
+          fixtureId: "fixture-456",
+        })
+      })
 
-      // Wait for updateBet with the correct betId (regression test for stale closure)
+      await user.click(incrementButton)
+
+      resolveCreate({
+        id: "new-bet-456",
+        user_bolao_id: "user-bolao-123",
+        fixture_id: "fixture-456",
+        value: 1,
+        type: "home",
+      })
+
       await waitFor(
         () => {
           expect(mockUpdateBet).toHaveBeenCalledWith({
             betId: "new-bet-456",
-            value: 1,
+            value: 2,
           })
         },
         { timeout: 2000 }
       )
 
-      // Should NOT have called createBet a second time
       expect(mockCreateBet).toHaveBeenCalledTimes(1)
+    })
+
+    it("flushes a pending save when the component unmounts", async () => {
+      const user = userEvent.setup()
+      const mockCreateBet = vi.mocked(actions.createBet)
+      mockCreateBet.mockResolvedValue({
+        id: "new-bet-123",
+        user_bolao_id: "user-bolao-123",
+        fixture_id: "fixture-456",
+        value: 1,
+        type: "home",
+      })
+
+      const { unmount } = render(<ButtonsBet {...defaultProps} />)
+
+      const buttons = screen.getAllByRole("button")
+      await user.click(buttons[1])
+      await user.click(buttons[1])
+
+      unmount()
+
+      await waitFor(() => {
+        expect(mockCreateBet).toHaveBeenCalledWith({
+          userBolaoId: "user-bolao-123",
+          value: 1,
+          type: "home",
+          fixtureId: "fixture-456",
+        })
+      })
     })
   })
 })

--- a/app/ui/bolao/bet/buttonsBet.tsx
+++ b/app/ui/bolao/bet/buttonsBet.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
+import { useTranslations } from "next-intl"
 import { createBet, updateBet } from "@/app/lib/actions"
 import { INITIAL_BET_VALUE } from "@/app/lib/utils"
 import { BetResult } from "@/app/lib/definitions"
+import { useToast } from "@/hooks/use-toast"
 import { Button } from "@/components/ui/button"
 import { PlusIcon, MinusIcon } from "@radix-ui/react-icons"
 
@@ -16,6 +18,21 @@ type Props = {
   disabled: boolean
 }
 
+function displayToSavedValue(display: string): number | null {
+  if (display === INITIAL_BET_VALUE) return null
+  return Number(display)
+}
+
+function savedValueToDisplay(saved: number | null): string {
+  return saved === null ? INITIAL_BET_VALUE : String(saved)
+}
+
+function isBetSaveSuccess(
+  result: BetResult
+): result is Extract<BetResult, { id: string }> {
+  return "id" in result && typeof result.id === "string"
+}
+
 function ButtonsBet({
   userBolaoId,
   type,
@@ -24,40 +41,128 @@ function ButtonsBet({
   betId,
   disabled,
 }: Props) {
-  const [value, setValue] = useState(
-    betValue !== undefined ? betValue : INITIAL_BET_VALUE
-  )
-  const [betIdValue, setBetId] = useState(betId || null)
+  const t = useTranslations("betPage")
+  const { toast } = useToast()
+  const initialSaved = betValue !== undefined ? betValue : null
+  const [value, setValue] = useState(savedValueToDisplay(initialSaved))
+  const [betIdValue, setBetIdValue] = useState(betId || null)
 
-  const setData = useCallback(async () => {
+  const valueRef = useRef(value)
+  const betIdRef = useRef(betId || null)
+  const savedValueRef = useRef<number | null>(initialSaved)
+  const isSavingRef = useRef(false)
+  const pendingSaveRef = useRef(false)
+
+  valueRef.current = value
+  betIdRef.current = betIdValue
+
+  useEffect(() => {
+    const saved = betValue !== undefined ? betValue : null
+    savedValueRef.current = saved
+    betIdRef.current = betId || null
+    setValue(savedValueToDisplay(saved))
+    setBetIdValue(betId || null)
+  }, [betValue, betId])
+
+  const showSaveError = useCallback(
+    (message?: string) => {
+      const isLocked = message === "Betting is locked for this fixture."
+      toast({
+        variant: "destructive",
+        title: t("saveErrorTitle"),
+        description: isLocked
+          ? t("saveLockedDescription")
+          : message || t("saveErrorDescription"),
+      })
+    },
+    [t, toast]
+  )
+
+  const persistBetRef = useRef<() => Promise<boolean>>(async () => true)
+
+  persistBetRef.current = async () => {
+    const numValue = displayToSavedValue(valueRef.current)
+    if (numValue === null) return true
+    if (numValue === savedValueRef.current) return true
+
+    if (isSavingRef.current) {
+      pendingSaveRef.current = true
+      return false
+    }
+
+    isSavingRef.current = true
+    pendingSaveRef.current = false
+    let savedSuccessfully = false
+
     try {
       let result: BetResult
 
-      if (betIdValue) {
-        const data = { betId: betIdValue, value: Number(value) }
-        result = await updateBet(data)
+      if (betIdRef.current) {
+        result = await updateBet({ betId: betIdRef.current, value: numValue })
       } else {
-        const data = { userBolaoId, value: Number(value), type, fixtureId }
-        result = await createBet(data)
+        result = await createBet({
+          userBolaoId,
+          value: numValue,
+          type,
+          fixtureId,
+        })
       }
 
-      if ("id" in result && !betIdValue) {
-        setBetId(result.id)
+      if (isBetSaveSuccess(result)) {
+        savedValueRef.current = numValue
+        betIdRef.current = result.id
+        setBetIdValue(result.id)
+        savedSuccessfully = true
+        return true
       }
+
+      showSaveError("message" in result ? result.message : undefined)
+      setValue(savedValueToDisplay(savedValueRef.current))
+      return false
     } catch (error) {
       console.error("Error creating/updating bet:", error)
+      showSaveError()
+      setValue(savedValueToDisplay(savedValueRef.current))
+      return false
+    } finally {
+      isSavingRef.current = false
+
+      if (!savedSuccessfully) {
+        pendingSaveRef.current = false
+        return
+      }
+
+      const currentValue = displayToSavedValue(valueRef.current)
+      const needsFollowUpSave =
+        pendingSaveRef.current ||
+        (currentValue !== null && currentValue !== savedValueRef.current)
+
+      pendingSaveRef.current = false
+
+      if (needsFollowUpSave) {
+        void persistBetRef.current()
+      }
     }
-  }, [betIdValue, value, userBolaoId, type, fixtureId])
+  }
 
   useEffect(() => {
-    const delayDebounceFn = setTimeout(() => {
-      if (value !== INITIAL_BET_VALUE) {
-        setData()
-      }
+    if (value === INITIAL_BET_VALUE) return
+
+    const timer = setTimeout(() => {
+      void persistBetRef.current()
     }, 300)
 
-    return () => clearTimeout(delayDebounceFn)
-  }, [value, setData])
+    return () => clearTimeout(timer)
+  }, [value])
+
+  useEffect(() => {
+    return () => {
+      const pendingValue = displayToSavedValue(valueRef.current)
+      if (pendingValue !== null && pendingValue !== savedValueRef.current) {
+        void persistBetRef.current()
+      }
+    }
+  }, [])
 
   const incrementCount = () => {
     if (value === INITIAL_BET_VALUE) {

--- a/app/ui/bolao/bet/buttonsBet.tsx
+++ b/app/ui/bolao/bet/buttonsBet.tsx
@@ -129,18 +129,17 @@ function ButtonsBet({
 
       if (!savedSuccessfully) {
         pendingSaveRef.current = false
-        return
-      }
+      } else {
+        const currentValue = displayToSavedValue(valueRef.current)
+        const needsFollowUpSave =
+          pendingSaveRef.current ||
+          (currentValue !== null && currentValue !== savedValueRef.current)
 
-      const currentValue = displayToSavedValue(valueRef.current)
-      const needsFollowUpSave =
-        pendingSaveRef.current ||
-        (currentValue !== null && currentValue !== savedValueRef.current)
+        pendingSaveRef.current = false
 
-      pendingSaveRef.current = false
-
-      if (needsFollowUpSave) {
-        void persistBetRef.current()
+        if (needsFollowUpSave) {
+          void persistBetRef.current()
+        }
       }
     }
   }

--- a/app/ui/bolao/results/__tests__/tableMatchDayResults.test.tsx
+++ b/app/ui/bolao/results/__tests__/tableMatchDayResults.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import { vi } from "vitest"
 import TableMatchDayResults from "../tableMatchDayResults"
+import { buildResultsTableView } from "@/app/lib/resultsTableData"
 import type { FixtureData, Bet, PlayersData } from "@/app/lib/definitions"
 import * as scoresCalcFactory from "@/app/lib/scoresCalcFactory"
 import * as utils from "@/app/lib/utils"
@@ -93,6 +94,29 @@ vi.mock("next/image", () => ({
 }))
 
 describe("TableMatchDayResults", () => {
+function renderTable(
+  fixtures: FixtureData[] | null | undefined,
+  bets: Bet[] = [],
+  players: PlayersData[] = mockPlayers,
+  currentUserId = "player1"
+) {
+  if (!fixtures) {
+    return render(<TableMatchDayResults tableView={null} />)
+  }
+
+  return render(
+    <TableMatchDayResults
+      tableView={buildResultsTableView({
+        fixtures,
+        bets,
+        players,
+        currentUserId,
+      })}
+    />
+  )
+}
+
+
   const mockPlayers: PlayersData[] = [
     {
       id: "player1",
@@ -202,27 +226,13 @@ describe("TableMatchDayResults", () => {
 
   describe("Loading State", () => {
     it("should show loading message when fixtures is falsy", () => {
-      render(
-        <TableMatchDayResults
-          fixtures={null as any}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(null as any)
 
       expect(screen.getByText("loading...")).toBeInTheDocument()
     })
 
     it("should show loading message when fixtures is undefined", () => {
-      render(
-        <TableMatchDayResults
-          fixtures={undefined as any}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(undefined as any)
 
       expect(screen.getByText("loading...")).toBeInTheDocument()
     })
@@ -239,14 +249,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       expect(screen.getByText("Next games")).toBeInTheDocument()
     })
@@ -261,14 +264,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       expect(screen.getByText("Next games")).toBeInTheDocument()
     })
@@ -283,14 +279,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       expect(screen.getByText("Previous games")).toBeInTheDocument()
     })
@@ -305,14 +294,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       expect(screen.getByText("Previous games")).toBeInTheDocument()
     })
@@ -322,14 +304,7 @@ describe("TableMatchDayResults", () => {
     it("should display player email usernames", () => {
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       expect(screen.getByText("john")).toBeInTheDocument()
       expect(screen.getByText("mike")).toBeInTheDocument()
@@ -338,14 +313,7 @@ describe("TableMatchDayResults", () => {
     it("should display email username for all players", () => {
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       // All players show email part before @
       expect(screen.getByText("jane")).toBeInTheDocument()
@@ -353,14 +321,7 @@ describe("TableMatchDayResults", () => {
 
     it("should display all players in order", () => {
       const fixtures = [createMockFixture()]
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures)
 
       // Check that all player names are rendered
       expect(screen.getByText("john")).toBeInTheDocument()
@@ -386,14 +347,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={playersWithUsername}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [], playersWithUsername)
 
       // Player1 has username, should display "johndoe"
       expect(screen.getByText("johndoe")).toBeInTheDocument()
@@ -406,14 +360,7 @@ describe("TableMatchDayResults", () => {
     it("should render fixture with team logos and names", () => {
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       // TeamCodeLogo components should be rendered
       const teamLogos = screen.getAllByTestId("team-code-logo")
@@ -426,14 +373,7 @@ describe("TableMatchDayResults", () => {
     it("should render fixture date component", () => {
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       expect(screen.getByTestId("fixture-date")).toBeInTheDocument()
     })
@@ -441,14 +381,7 @@ describe("TableMatchDayResults", () => {
     it("should render team score components", () => {
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       const teamScores = screen.getAllByTestId("team-score")
       expect(teamScores).toHaveLength(2) // home and away
@@ -467,14 +400,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures)
 
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
       // 1 header row + 3 fixture rows
@@ -488,14 +414,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [createMockFixture()]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures)
 
       // Should show ".-." (INITIAL_BET_VALUE-INITIAL_BET_VALUE)
       const betCells = container.querySelectorAll('[data-testid="sticky-cell"]')
@@ -521,14 +440,7 @@ describe("TableMatchDayResults", () => {
         createMockBet({ type: "away", value: 1 }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={bets}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, bets)
 
       // Should show "2-1" for at least one player
       const betCells = container.querySelectorAll('[data-testid="sticky-cell"]')
@@ -562,14 +474,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       // Current user (player1) should see their bets
       // Other players should see ".-."
@@ -592,14 +497,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       // All players should see bets since game is finished
       expect(utils.findBetObj).toHaveBeenCalled()
@@ -617,14 +515,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       // All players should see bets since game is in play
       expect(utils.findBetObj).toHaveBeenCalled()
@@ -645,14 +536,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       // Should display "5 pts" for calculated score
       const scoreCells = container.querySelectorAll(
@@ -688,14 +572,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       expect(scoresCalcFactory.calcScore).toHaveBeenCalledWith({
         resultHome: 2,
@@ -717,14 +594,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       // Should NOT display pts for individual fixtures not started (totals row will show 0 pts)
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
@@ -759,14 +629,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       expect(scoresCalcFactory.calcScore).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -795,14 +658,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       expect(scoresCalcFactory.calcScore).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -837,14 +693,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       expect(scoresCalcFactory.calcScore).toHaveBeenCalledWith({
         resultHome: 3,
@@ -871,14 +720,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures)
 
       const cells = container.querySelectorAll('[data-testid="sticky-cell"]')
       const cellsWithBg = Array.from(cells).filter((cell) => {
@@ -901,14 +743,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures)
 
       const cells = container.querySelectorAll('[data-testid="sticky-cell"]')
       const cellsWithoutBg = Array.from(cells).filter((cell) => {
@@ -927,14 +762,7 @@ describe("TableMatchDayResults", () => {
     it("should handle empty players array", () => {
       const fixtures = [createMockFixture()]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={[]}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [], [])
 
       // Should still render but with no player columns
       expect(
@@ -947,14 +775,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       // Should render with INITIAL_BET_VALUE
       expect(screen.getByTestId("sticky-table")).toBeInTheDocument()
@@ -973,14 +794,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       // Should not crash
       expect(screen.getByTestId("sticky-table")).toBeInTheDocument()
@@ -999,14 +813,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [createMockFixture()]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={playersWithLongEmail}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [], playersWithLongEmail)
 
       // Should display the part before @
       expect(
@@ -1026,14 +833,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       expect(screen.getByText("Previous games")).toBeInTheDocument()
     })
@@ -1050,14 +850,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures, [createMockBet()])
 
       // All players showing same bets should work fine
       expect(screen.getByTestId("sticky-table")).toBeInTheDocument()
@@ -1070,14 +863,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [createMockFixture()]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures)
 
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
       // 1 header row + 1 fixture row + 1 totals row
@@ -1099,14 +885,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       const totalsText = screen.getAllByText("0 pts")
       // Should have 3 players with 0 pts in totals row
@@ -1153,14 +932,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       // Check totals row (last row)
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
@@ -1191,14 +963,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       // Check totals row specifically (last row)
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
@@ -1236,14 +1001,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       // Check totals row specifically (last row)
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
@@ -1276,14 +1034,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      renderTable(fixtures)
 
       // Should show 0 pts when bets are incomplete
       expect(screen.getAllByText("0 pts").length).toBeGreaterThan(0)
@@ -1294,14 +1045,7 @@ describe("TableMatchDayResults", () => {
 
       const fixtures = [createMockFixture()]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures)
 
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
       const lastRow = rows[rows.length - 1]
@@ -1327,14 +1071,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')
       const totalsRow = rows[rows.length - 1]
@@ -1377,14 +1114,7 @@ describe("TableMatchDayResults", () => {
         }),
       ]
 
-      const { container } = render(
-        <TableMatchDayResults
-          fixtures={fixtures}
-          bets={[createMockBet()]}
-          players={mockPlayers}
-          userId="player1"
-        />
-      )
+      const { container } = renderTable(fixtures, [createMockBet()])
 
       // Check totals row specifically (last row)
       const rows = container.querySelectorAll('[data-testid="sticky-row"]')

--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -1,17 +1,8 @@
 "use client"
 
 import { useTranslations, useLocale } from "next-intl"
-import { FixtureData, Bet, PlayersData } from "@/app/lib/definitions"
-import {
-  findBetObj,
-  INITIAL_BET_VALUE,
-  STATUSES_FINISHED,
-  STATUSES_IN_PLAY,
-  STATUSES_OPEN_TO_PLAY,
-  getEmailUsername,
-  getFixtureResultScores,
-} from "@/app/lib/utils"
-import { calcScore } from "@/app/lib/scoresCalcFactory"
+import { STATUSES_OPEN_TO_PLAY } from "@/app/lib/utils"
+import { ResultsTableView } from "@/app/lib/resultsTableData"
 import { StickyTable, Row, Cell } from "react-sticky-table"
 import TeamCodeLogo from "@/app/ui/bolao/teamCodeLogo"
 import TeamScore from "@/app/ui/bolao/teamScore"
@@ -19,10 +10,7 @@ import FixtureDate from "@/app/ui/bolao/fixtureDate"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 type TableProps = {
-  fixtures: FixtureData[]
-  bets: Bet[]
-  players: PlayersData[]
-  userId: string //Could be in context
+  tableView: ResultsTableView | null
 }
 
 const cellStyles = {
@@ -40,119 +28,51 @@ const headerCellStyles = {
 
 const totalsCellStyles = {
   ...cellStyles,
-  borderTop: "1px solid rgb(226 232 240)", // border-slate-200
+  borderTop: "1px solid rgb(226 232 240)",
   padding: "12px 0",
   fontWeight: 600,
   backgroundColor: "white",
 }
 
-function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
+function TableMatchDayResults({ tableView }: TableProps) {
   const t = useTranslations("resultsPage")
   const locale = useLocale()
 
-  // Totals include finished fixtures and live in-play scores
-  const calculatePlayerTotal = (userBolaoId: string): number => {
-    let total = 0
-
-    fixtures.forEach((fixtureData) => {
-      const statusShort = fixtureData.fixture.status.short
-      const scoresVisible =
-        STATUSES_IN_PLAY.includes(statusShort) ||
-        STATUSES_FINISHED.includes(statusShort)
-
-      if (!scoresVisible) return
-
-      const homeBetObj = findBetObj({
-        bets,
-        fixtureId: fixtureData.fixture.id.toString(),
-        type: "home",
-        userBolaoId,
-      })
-
-      const awayBetObj = findBetObj({
-        bets,
-        fixtureId: fixtureData.fixture.id.toString(),
-        type: "away",
-        userBolaoId,
-      })
-
-      if (
-        homeBetObj?.value !== undefined &&
-        awayBetObj?.value !== undefined
-      ) {
-        const { resultHome, resultAway } = getFixtureResultScores(
-          fixtureData,
-          statusShort
-        )
-
-        const fixtureScore = calcScore({
-          resultHome,
-          resultAway,
-          betHome: homeBetObj.value,
-          betAway: awayBetObj.value,
-        })
-
-        total = total + fixtureScore
-      }
-    })
-
-    return total
+  if (!tableView) {
+    return <p>{t("loading")}</p>
   }
 
-  if (fixtures) {
-    return (
-      <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
-        <Card className="max-md:rounded-none max-md:border-x-0 max-md:shadow-none md:rounded-xl md:border-x md:shadow-sm">
-          <CardHeader className="p-4 md:p-6">
-            <CardTitle>
-              {STATUSES_OPEN_TO_PLAY.includes(
-                fixtures[fixtures.length - 1].fixture.status.short
-              )
-                ? t("nextGames")
-                : t("previousGames")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-[min(70vh,800px)] w-full max-md:h-[55vh]">
-              <StickyTable borderWidth={0} stickyFooterCount={1}>
+  const { players, rows, totals } = tableView
+  const lastFixtureStatus =
+    rows[rows.length - 1]?.fixture.fixture.status.short ?? "NS"
+
+  return (
+    <div className="max-md:mx-[calc((100dvw-100%)/-2)] md:mx-0">
+      <Card className="max-md:rounded-none max-md:border-x-0 max-md:shadow-none md:rounded-xl md:border-x md:shadow-sm">
+        <CardHeader className="p-4 md:p-6">
+          <CardTitle>
+            {STATUSES_OPEN_TO_PLAY.includes(lastFixtureStatus)
+              ? t("nextGames")
+              : t("previousGames")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[min(70vh,800px)] w-full max-md:h-[55vh]">
+            <StickyTable borderWidth={0} stickyFooterCount={1}>
               <Row>
                 <Cell style={headerCellStyles}>&nbsp;</Cell>
-                {players.map((player: PlayersData) => {
-                  return (
-                    <Cell style={headerCellStyles} key={player.id}>
-                      <span className="font-semibold text-sm px-2">
-                        {player.username || getEmailUsername(player.email)}
-                      </span>
-                    </Cell>
-                  )
-                })}
+                {players.map((player, index) => (
+                  <Cell style={headerCellStyles} key={`player_${index}`}>
+                    <span className="font-semibold text-sm px-2">
+                      {player.displayName}
+                    </span>
+                  </Cell>
+                ))}
               </Row>
 
-              {fixtures.map((fixtureData: FixtureData, i: number) => {
+              {rows.map((row, rowIndex) => {
+                const fixtureData = row.fixture
                 const statusShort = fixtureData.fixture.status.short
-                const canShowScores =
-                  STATUSES_IN_PLAY.includes(statusShort) ||
-                  STATUSES_FINISHED.includes(statusShort)
-
-                const getBet = ({
-                  type,
-                  userBolaoId,
-                }: {
-                  type: "home" | "away"
-                  userBolaoId: string
-                }) => {
-                  const obj = findBetObj({
-                    bets,
-                    fixtureId: fixtureData.fixture.id.toString(),
-                    type,
-                    userBolaoId,
-                  })
-
-                  if (obj) {
-                    return obj.value.toString()
-                  }
-                  return INITIAL_BET_VALUE
-                }
 
                 return (
                   <Row key={fixtureData.fixture.id}>
@@ -161,7 +81,8 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
                         padding: "8px 0",
                         margin: 0,
                         border: 0,
-                        backgroundColor: i % 2 !== 0 ? "rgb(248 250 252)" : "", //bg-slate-50
+                        backgroundColor:
+                          rowIndex % 2 !== 0 ? "rgb(248 250 252)" : "",
                       }}
                     >
                       <div className="flex justify-center content-center">
@@ -202,53 +123,26 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
                       </div>
                     </Cell>
 
-                    {players.map((player) => {
-                      const showScores = player.id === userId || canShowScores
-
-                      const betHome = getBet({
-                        type: "home",
-                        userBolaoId: player.userBolaoId,
-                      })
-                      const betAway = getBet({
-                        type: "away",
-                        userBolaoId: player.userBolaoId,
-                      })
-
-                      let score = 0
-                      if (canShowScores) {
-                        const { resultHome, resultAway } =
-                          getFixtureResultScores(fixtureData, statusShort)
-
-                        score = calcScore({
-                          resultHome,
-                          resultAway,
-                          betHome: Number(betHome),
-                          betAway: Number(betAway),
-                        })
-                      }
-
-                      return (
-                        <Cell
-                          style={{
-                            padding: 0,
-                            margin: 0,
-                            border: 0,
-                            backgroundColor:
-                              i % 2 !== 0 ? "rgb(248 250 252)" : "",
-                          }}
-                          key={`${fixtureData.fixture.id}_${player.id}`}
-                          className="text-center"
-                        >
-                          <div>
-                            {showScores ? betHome : INITIAL_BET_VALUE}-
-                            {showScores ? betAway : INITIAL_BET_VALUE}
-                          </div>
-                          {canShowScores && (
-                            <div className="text-sm px-2">{`${score} pts`}</div>
-                          )}
-                        </Cell>
-                      )
-                    })}
+                    {row.cells.map((cell, cellIndex) => (
+                      <Cell
+                        style={{
+                          padding: 0,
+                          margin: 0,
+                          border: 0,
+                          backgroundColor:
+                            rowIndex % 2 !== 0 ? "rgb(248 250 252)" : "",
+                        }}
+                        key={`${fixtureData.fixture.id}_${cellIndex}`}
+                        className="text-center"
+                      >
+                        <div>
+                          {cell.home}-{cell.away}
+                        </div>
+                        {cell.points !== null && (
+                          <div className="text-sm px-2">{`${cell.points} pts`}</div>
+                        )}
+                      </Cell>
+                    ))}
                   </Row>
                 )
               })}
@@ -257,28 +151,22 @@ function TableMatchDayResults({ fixtures, bets, players, userId }: TableProps) {
                 <Cell style={totalsCellStyles}>
                   <div className="text-left pl-6">{t("total")}</div>
                 </Cell>
-                {players.map((player) => {
-                  const total = calculatePlayerTotal(player.userBolaoId)
-                  return (
-                    <Cell
-                      style={totalsCellStyles}
-                      key={`total_${player.id}`}
-                      className="text-center"
-                    >
-                      <div className="text-sm">{`${total} pts`}</div>
-                    </Cell>
-                  )
-                })}
+                {totals.map((total, index) => (
+                  <Cell
+                    style={totalsCellStyles}
+                    key={`total_${index}`}
+                    className="text-center"
+                  >
+                    <div className="text-sm">{`${total} pts`}</div>
+                  </Cell>
+                ))}
               </Row>
             </StickyTable>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    )
-  }
-
-  return <p>{t("loading")}</p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
 }
 
 export default TableMatchDayResults

--- a/messages/en.json
+++ b/messages/en.json
@@ -151,7 +151,10 @@
     "selectPlayer": "Select player",
     "selectPlayerToBetAs": "Select player to bet as",
     "loading": "loading...",
-    "errorLoadFailed": "Could not load the bet page. Check your connection and try again."
+    "errorLoadFailed": "Could not load the bet page. Check your connection and try again.",
+    "saveErrorTitle": "Could not save bet",
+    "saveErrorDescription": "Something went wrong while saving your bet. Please try again.",
+    "saveLockedDescription": "Betting is closed for this match. Your change was not saved."
   },
   "resultsPage": {
     "nextGames": "Next games",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -151,7 +151,10 @@
     "selectPlayer": "Selecionar jogador",
     "selectPlayerToBetAs": "Selecionar jogador para apostar como",
     "loading": "carregando...",
-    "errorLoadFailed": "Não foi possível carregar a página de apostas. Verifique sua conexão e tente novamente."
+    "errorLoadFailed": "Não foi possível carregar a página de apostas. Verifique sua conexão e tente novamente.",
+    "saveErrorTitle": "Não foi possível salvar o palpite",
+    "saveErrorDescription": "Algo deu errado ao salvar seu palpite. Tente novamente.",
+    "saveLockedDescription": "Apostas encerradas para este jogo. Sua alteração não foi salva."
   },
   "resultsPage": {
     "nextGames": "Próximos jogos",


### PR DESCRIPTION
## Summary
- Add server-side auth, ownership, and fixture lock checks to `createBet`, `updateBet`, and `deleteBet` so players cannot bypass UI restrictions via direct requests.
- Harden bet saving in the UI with unmount flush, serialized follow-up saves, error toasts, and revert-to-last-saved behavior when persistence fails.
- Add EN/PT-BR copy for bet save errors and expand unit test coverage.

## Test plan
- [x] `yarn test app/lib/__tests__/actions.test.ts`
- [x] `yarn test app/ui/bolao/bet/__tests__/buttonsBet.test.tsx`
- [x] `yarn test app/lib/__tests__/utils.test.ts`
- [ ] Manually place both home/away bets, navigate away quickly, and confirm both persist
- [ ] Attempt to change a bet after kickoff and confirm server rejection + error toast


Made with [Cursor](https://cursor.com)