### PR TITLE
fix(results): default to the latest current round like bet page

### DIFF
--- a/app/lib/__tests__/controllerResults.test.ts
+++ b/app/lib/__tests__/controllerResults.test.ts
@@ -395,6 +395,44 @@ describe("controllerResults", () => {
       expect(result.currentRound).toBe("Round 3")
     })
 
+    it("should pick the last API current label when multiple rounds are current", async () => {
+      const {
+        fetchBolao,
+        fetchUsersBolao,
+        fetchRounds,
+        fetchFixtures,
+        fetchUsersBets,
+      } = await import("@/app/lib/data")
+      const { clerkClient } = await import("@clerk/nextjs/server")
+
+      const worldCupRounds = [
+        "Group Stage - 1",
+        "Group Stage - 2",
+        "Group Stage - 3",
+        "Round of 16",
+        "Quarter-finals",
+      ]
+
+      const mockClient = {
+        users: {
+          getUserList: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      }
+
+      vi.mocked(fetchBolao).mockResolvedValue(mockBolao as any)
+      vi.mocked(fetchUsersBolao).mockResolvedValue([] as any)
+      vi.mocked(fetchRounds)
+        .mockResolvedValueOnce(worldCupRounds)
+        .mockResolvedValueOnce(["Group Stage - 3", "Round of 16"])
+      vi.mocked(fetchFixtures).mockResolvedValue([])
+      vi.mocked(fetchUsersBets).mockResolvedValue([])
+      vi.mocked(clerkClient).mockResolvedValue(mockClient as any)
+
+      const result = await getData({ bolaoId: "bolao-1" })
+
+      expect(result.currentRound).toBe("Round of 16")
+    })
+
     it("should fallback to last round when currentRound is empty", async () => {
       const {
         fetchBolao,

--- a/app/lib/controllerResults.ts
+++ b/app/lib/controllerResults.ts
@@ -47,7 +47,7 @@ export async function getData({
   const currentRound = pickCurrentRoundFromApiCurrent(
     currentRoundObj,
     allRounds,
-    "first"
+    "last"
   )
 
   let isFirstRound: boolean = false


### PR DESCRIPTION
## Summary
- Align results page default round selection with the bet page by using the `"last"` strategy in `pickCurrentRoundFromApiCurrent`
- Fixes World Cup navigation where the API marks both group stage and knockout rounds as current, causing results to open on the first group instead of the active knockout round
- Add a controller test covering the multi-current-round World Cup scenario

## Test plan
- [x] `yarn test app/lib/__tests__/controllerResults.test.ts`
- [ ] Open a World Cup bolão, click the Results tab, and confirm it lands on the current knockout round (not the first group stage)
- [ ] Confirm bet and results tabs still open on the same round by default


Made with [Cursor](https://cursor.com)