### PR TITLE
fix(results): polish totals row and show 0 pts for incomplete bets

### DIFF
--- a/app/lib/__tests__/resultsTableData.test.ts
+++ b/app/lib/__tests__/resultsTableData.test.ts
@@ -149,4 +149,29 @@ describe("buildResultsTableView", () => {
     expect(view.rows[0].cells[1].away).toBe("0")
     expect(view.rows[0].cells[1].points).not.toBeNull()
   })
+
+  it("shows 0 points when a player has an incomplete bet on a finished fixture", () => {
+    const bets: Bet[] = [
+      {
+        id: "bet-1",
+        user_bolao_id: "ub-2",
+        fixture_id: "12345",
+        value: 2,
+        type: "home",
+      },
+    ]
+
+    const view = buildResultsTableView({
+      fixtures: [createFixture("FT")],
+      bets,
+      players: mockPlayers,
+      currentUserId: "player1",
+    })
+
+    expect(view.rows[0].cells[1]).toEqual({
+      home: "2",
+      away: ".",
+      points: 0,
+    })
+  })
 })

--- a/app/lib/resultsTableData.ts
+++ b/app/lib/resultsTableData.ts
@@ -129,22 +129,25 @@ export function buildResultsTableView({
         : INITIAL_BET_VALUE
 
       let points: number | null = null
-      if (
-        canShowScores &&
-        homeBetObj?.value !== undefined &&
-        awayBetObj?.value !== undefined
-      ) {
-        const { resultHome, resultAway } = getFixtureResultScores(
-          fixtureData,
-          statusShort
-        )
+      if (canShowScores) {
+        if (
+          homeBetObj?.value !== undefined &&
+          awayBetObj?.value !== undefined
+        ) {
+          const { resultHome, resultAway } = getFixtureResultScores(
+            fixtureData,
+            statusShort
+          )
 
-        points = calcScore({
-          resultHome,
-          resultAway,
-          betHome: homeBetObj.value,
-          betAway: awayBetObj.value,
-        })
+          points = calcScore({
+            resultHome,
+            resultAway,
+            betHome: homeBetObj.value,
+            betAway: awayBetObj.value,
+          })
+        } else {
+          points = 0
+        }
       }
 
       return {

--- a/app/ui/bolao/results/tableMatchDayResults.tsx
+++ b/app/ui/bolao/results/tableMatchDayResults.tsx
@@ -29,8 +29,8 @@ const headerCellStyles = {
 const totalsCellStyles = {
   ...cellStyles,
   borderTop: "1px solid rgb(226 232 240)",
-  padding: "12px 0",
-  fontWeight: 600,
+  padding: "12px 10px",
+  fontWeight: 400,
   backgroundColor: "white",
 }
 


### PR DESCRIPTION
## Summary
- Lighten the totals row font weight and add horizontal padding so the sticky footer is easier to read when scrolling.
- Show `0 pts` for players who submitted only one side of a bet on live or finished fixtures, instead of leaving the points line blank.

## Test plan
- [ ] Open a bolão results table with a wide player list and confirm the totals row is easier to scan horizontally
- [ ] Find a fixture where a player has an incomplete bet (e.g. `2-.` or `.-.`) and confirm it shows `0 pts` after kickoff
- [ ] Confirm complete bets still show the correct calculated points
- [x] `yarn test app/lib/__tests__/resultsTableData.test.ts`


Made with [Cursor](https://cursor.com)